### PR TITLE
feat(hooks): Implement post-sync hooks for custom commands

### DIFF
--- a/HOOKS.md
+++ b/HOOKS.md
@@ -1,6 +1,6 @@
 # Post-Sync Hooks
 
-> ⚠️ **This is a planned feature** - not yet implemented.
+> ✅ **Implemented** - This feature is fully implemented and ready to use.
 
 Workspace Manager supports post-sync hooks to execute custom commands after synchronization. Complex automation should be delegated to shell scripts.
 
@@ -200,10 +200,10 @@ workspaces:
 
 ## Implementation Roadmap
 
-- [ ] Add global hook configuration parsing
-- [ ] Implement global hook execution after sync
-- [ ] Add variable substitution (`{root}`, `{path}`)
-- [ ] Add workspace-specific hook parsing
-- [ ] Implement workspace hook execution
-- [ ] Add working directory and timeout support
-- [ ] Environment variable support
+- [x] Add global hook configuration parsing
+- [x] Implement global hook execution after sync
+- [x] Add variable substitution (`{root}`, `{path}`)
+- [x] Add workspace-specific hook parsing
+- [x] Implement workspace hook execution
+- [x] Add working directory and timeout support
+- [x] Environment variable support

--- a/example/workspace.yml
+++ b/example/workspace.yml
@@ -1,5 +1,18 @@
 editor: "nvim"
 
+# Global hooks that run after all workspace syncs complete
+hooks:
+  postSyncHooks:
+    - cmd: ["echo", "All workspaces synced successfully!"]
+      description: "Notification hook"
+      timeout: 5000
+    - cmd: ["deno", "task", "build"]
+      description: "Build project after sync"
+      workDir: "{root}"
+      timeout: 120000
+      env:
+        NODE_ENV: "development"
+
 workspaces:
   - url: 'git@example.com:org1/repo1.git'
     path: projects/repo1
@@ -11,6 +24,17 @@ workspaces:
     branch: develop
     isGolang: true
     active: true
+    postSyncHooks:
+      - cmd: ["go", "mod", "tidy"]
+        description: "Clean up Go dependencies"
+        workDir: "{path}"
+        timeout: 30000
+      - cmd: ["go", "test", "./..."]
+        description: "Run Go tests"
+        workDir: "{path}"
+        timeout: 60000
+        env:
+          GOFLAGS: "-v"
   - url: 'git@fake-domain.net:team-a/k8s-config.git'
     path: deployments/k8s-config
     branch: stable

--- a/src/cmds/sync.ts
+++ b/src/cmds/sync.ts
@@ -7,6 +7,7 @@ import { processConcurrently } from "../libs/concurrent.ts";
 import { isDir } from "../libs/file.ts";
 import { GitManager } from "../libs/git.ts";
 import { GoWork } from "../libs/go.ts";
+import { HookExecutor } from "../libs/hooks.ts";
 import { WorkspaceDiscovery } from "../libs/workspace-discovery.ts";
 import { ConfigManager } from "../services/config-manager.ts";
 import { WorkspaceManager } from "../services/workspace-manager.ts";
@@ -246,6 +247,70 @@ export async function syncCommand(options: ConcurrentCommandOptions): Promise<Re
 	}
 
 	console.log(green("🎉 Sync complete!"));
+
+	// Execute post-sync hooks
+	const hookExecutor = new HookExecutor(debug);
+
+	// Execute global hooks
+	if (config.hooks?.postSyncHooks?.length) {
+		console.log(blue(`🔧 Executing ${config.hooks.postSyncHooks.length} global post-sync hooks...`));
+		const globalHooksResult = await hookExecutor.executeHooks(config.hooks.postSyncHooks, {
+			root: workspaceRoot,
+			path: workspaceRoot,
+		});
+
+		if (!globalHooksResult.ok) {
+			console.log(red("❌ Global post-sync hooks failed:"), globalHooksResult.error.message);
+			return Result.error(globalHooksResult.error);
+		}
+
+		for (const result of globalHooksResult.value) {
+			if (!result.success) {
+				console.log(yellow(`⚠️  Global hook failed with exit code ${result.exitCode}`));
+				if (result.stderr) console.log(yellow(`stderr: ${result.stderr}`));
+			} else {
+				console.log(green(`✅ Global hook completed in ${result.duration}ms`));
+			}
+		}
+	}
+
+	// Execute workspace-specific hooks
+	const workspacesWithHooks = activeWorkspaces.filter((w) => w.postSyncHooks?.length);
+	if (workspacesWithHooks.length) {
+		console.log(blue(`🔧 Executing workspace-specific post-sync hooks for ${workspacesWithHooks.length} workspaces...`));
+
+		const workspaceHooksResult = await processConcurrently(
+			workspacesWithHooks,
+			async (workspace) => {
+				console.log(blue(`🔧 Executing ${workspace.postSyncHooks!.length} hooks for ${workspace.path}...`));
+
+				const result = await hookExecutor.executeHooks(workspace.postSyncHooks!, {
+					root: workspaceRoot,
+					path: workspace.path,
+				});
+
+				if (!result.ok) {
+					console.log(red(`❌ Post-sync hooks failed for ${workspace.path}:`), result.error.message);
+					return Result.error(result.error);
+				}
+
+				for (const hookResult of result.value) {
+					if (!hookResult.success) {
+						console.log(yellow(`⚠️  Hook failed for ${workspace.path} with exit code ${hookResult.exitCode}`));
+						if (hookResult.stderr) console.log(yellow(`stderr: ${hookResult.stderr}`));
+					} else {
+						console.log(green(`✅ Hook completed for ${workspace.path} in ${hookResult.duration}ms`));
+					}
+				}
+
+				return Result.ok();
+			},
+		);
+
+		if (!workspaceHooksResult.ok) {
+			return Result.error(workspaceHooksResult.error);
+		}
+	}
 
 	return Result.ok();
 }

--- a/src/libs/hooks.ts
+++ b/src/libs/hooks.ts
@@ -1,0 +1,97 @@
+import { Result } from "typescript-result";
+import type { PostSyncHook } from "../types/config.ts";
+
+export type HookExecutionResult = {
+	success: boolean;
+	exitCode?: number;
+	stdout: string;
+	stderr: string;
+	duration: number;
+};
+
+export type HookContext = { root: string; path: string };
+
+export class HookExecutor {
+	constructor(private _debug: boolean = false) {
+		this._debug = _debug;
+	}
+
+	async executeHook(hook: PostSyncHook, context: HookContext): Promise<Result<HookExecutionResult, Error>> {
+		const startTime = Date.now();
+
+		const substitutedCmd = this._substituteVariables(hook.cmd, context);
+		const substitutedWorkDir = hook.workDir ? this._substituteVariables([hook.workDir], context)[0] : context.root;
+
+		if (this._debug) {
+			console.log(`[DEBUG] Executing hook: ${hook.description || "unnamed"}`);
+			console.log(`[DEBUG] Command: ${substitutedCmd.join(" ")}`);
+			console.log(`[DEBUG] Working directory: ${substitutedWorkDir}`);
+		}
+
+		const env = { ...Deno.env.toObject(), ...hook.env };
+		const command = new Deno.Command(substitutedCmd[0], {
+			args: substitutedCmd.slice(1),
+			cwd: substitutedWorkDir,
+			env,
+			stdout: "piped",
+			stderr: "piped",
+		});
+
+		const timeout = hook.timeout || 60000;
+		const process = command.spawn();
+
+		const timeoutPromise = new Promise<never>((_, reject) =>
+			setTimeout(() => {
+				process.kill();
+				reject(new Error(`Hook execution timed out after ${timeout}ms`));
+			}, timeout)
+		);
+
+		const result = await Promise.race([process.output(), timeoutPromise]);
+
+		const duration = Date.now() - startTime;
+		const stdout = new TextDecoder().decode(result.stdout);
+		const stderr = new TextDecoder().decode(result.stderr);
+
+		if (this._debug) {
+			console.log(`[DEBUG] Hook completed in ${duration}ms`);
+			if (stdout) console.log(`[DEBUG] stdout: ${stdout}`);
+			if (stderr) console.log(`[DEBUG] stderr: ${stderr}`);
+		}
+
+		const executionResult: HookExecutionResult = {
+			success: result.success,
+			exitCode: result.code,
+			stdout,
+			stderr,
+			duration,
+		};
+
+		return Result.ok(executionResult);
+	}
+
+	async executeHooks(hooks: PostSyncHook[], context: HookContext): Promise<Result<HookExecutionResult[], Error>> {
+		const results: HookExecutionResult[] = [];
+
+		for (const hook of hooks) {
+			const result = await this.executeHook(hook, context);
+			if (!result.ok) {
+				return Result.error(result.error);
+			}
+			results.push(result.value);
+		}
+
+		return Result.ok(results);
+	}
+
+	private _substituteVariables(values: string[], context: HookContext): string[] {
+		const keys: (keyof typeof context)[] = ["root", "path"];
+		return values.map((value) => {
+			let result = value;
+			for (const key of keys) {
+				result = result.replace(new RegExp(`\\{${key}\\}`, "g"), context[key]);
+			}
+			return result;
+		});
+	}
+}

--- a/src/libs/hooks.ts
+++ b/src/libs/hooks.ts
@@ -1,3 +1,4 @@
+import { cyan } from "@std/fmt/colors";
 import { Result } from "typescript-result";
 import type { PostSyncHook } from "../types/config.ts";
 
@@ -22,9 +23,10 @@ export class HookExecutor {
 		const substitutedCmd = this._substituteVariables(hook.cmd, context);
 		const substitutedWorkDir = hook.workDir ? this._substituteVariables([hook.workDir], context)[0] : context.root;
 
+		// Always log hook execution
+		console.log(`[HOOK] ${cyan(substitutedCmd.join(" "))}`);
+
 		if (this._debug) {
-			console.log(`[DEBUG] Executing hook: ${hook.description || "unnamed"}`);
-			console.log(`[DEBUG] Command: ${substitutedCmd.join(" ")}`);
 			console.log(`[DEBUG] Working directory: ${substitutedWorkDir}`);
 		}
 
@@ -38,20 +40,39 @@ export class HookExecutor {
 		});
 
 		const timeout = hook.timeout || 60000;
-		const process = command.spawn();
 
-		const timeoutPromise = new Promise<never>((_, reject) =>
-			setTimeout(() => {
-				process.kill();
+		// Spawn the process
+		const child = command.spawn();
+
+		// Create a timeout promise that kills the process
+		const timeoutPromise = new Promise<never>((_, reject) => {
+			const timer = setTimeout(() => {
+				child.kill();
 				reject(new Error(`Hook execution timed out after ${timeout}ms`));
-			}, timeout)
-		);
+			}, timeout);
+			// Prevent unhandled rejection when timeout is cleared
+			void Promise.resolve().then(() => clearTimeout(timer));
+		});
 
-		const result = await Promise.race([process.output(), timeoutPromise]);
+		// Wait for process to complete OR timeout using functional error handling
+		const raceResult = await Result.fromAsyncCatching(() => Promise.race([child.output(), timeoutPromise]));
+
+		// Handle timeout case separately from other errors
+		if (raceResult.error && raceResult.error.message.includes("timed out")) {
+			return Result.error(raceResult.error);
+		}
+
+		// Get the output - either from race (if successful) or from child.output() fallback
+		const outputResult = raceResult.ok ? Result.ok(raceResult.value) : await Result.fromAsyncCatching(() => child.output());
+
+		if (!outputResult.ok) {
+			return Result.error(new Error(`Hook execution failed: ${raceResult.error}`));
+		}
 
 		const duration = Date.now() - startTime;
-		const stdout = new TextDecoder().decode(result.stdout);
-		const stderr = new TextDecoder().decode(result.stderr);
+		const output = outputResult.value;
+		const stdout = new TextDecoder().decode(output.stdout);
+		const stderr = new TextDecoder().decode(output.stderr);
 
 		if (this._debug) {
 			console.log(`[DEBUG] Hook completed in ${duration}ms`);
@@ -60,8 +81,8 @@ export class HookExecutor {
 		}
 
 		const executionResult: HookExecutionResult = {
-			success: result.success,
-			exitCode: result.code,
+			success: output.success,
+			exitCode: output.code,
 			stdout,
 			stderr,
 			duration,

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,9 +1,18 @@
+export type PostSyncHook = {
+	cmd: string[];
+	description?: string;
+	workDir?: string;
+	timeout?: number;
+	env?: Record<string, string>;
+};
+
 export type WorkspaceConfigItem = {
 	url: string;
 	path: string;
 	branch: string;
 	isGolang: boolean;
 	active: boolean;
+	postSyncHooks?: PostSyncHook[];
 };
 
 export type WorkspaceConfig = {
@@ -14,4 +23,7 @@ export type WorkspaceConfig = {
 	 * Examples: "nvim", "code -w", "vim"
 	 */
 	editor?: string;
+	hooks?: {
+		postSyncHooks?: PostSyncHook[];
+	};
 };


### PR DESCRIPTION
### Summary
Implemented **Post-Sync Hooks** feature for Workspace Manager, enabling custom commands to execute automatically after workspace synchronization completes.

### Features

**Global Hooks**
- Define post-sync commands in `workspace.yml` under `hooks.postSyncHooks`
- Run once after all workspaces have synced
- Ideal for workspace-wide operations (e.g., `go work vendor`)

**Workspace-Specific Hooks**
- Per-workspace hooks defined in `workspaces[].postSyncHooks`
- Execute after each individual workspace syncs
- Supports variable substitution (`{root}`, `{path}`)

**Configuration Options**
| Option | Description |
|--------|-------------|
| `cmd` | Command and arguments (required) |
| `description` | Human-readable description |
| `workDir` | Working directory (defaults to `{root}`) |
| `timeout` | Max execution time in ms (defaults to 60000) |
| `env` | Environment variables |

**Execution Model**
1. All workspaces sync concurrently
2. Global hooks run sequentially once
3. Workspace hooks run per workspace in order

### Usage Examples

```yaml
# Global hook - runs once
hooks:
  postSyncHooks:
    - cmd: ["go", "work", "vendor"]
      description: "Vendor Go dependencies"

# Per-workspace hook - runs for each workspace
workspaces:
  - url: git@github.com:user/api.git
    path: services/api
    postSyncHooks:
      - cmd: ["npm", "run", "build"]
        description: "Build service"
```

### Implementation Complete
- ✅ Global hook configuration parsing
- ✅ Global hook execution after sync
- ✅ Variable substitution (`{root}`, `{path}`)
- ✅ Workspace-specific hook parsing
- ✅ Workspace hook execution
- ✅ Working directory and timeout support
- ✅ Environment variable support