### PR TITLE
feat(link): add `link` command for symlinking workspace files into submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ workspace-manager open
 workspace-manager add
 workspace-manager save
 workspace-manager status
+workspace-manager link
 workspace-manager completions
 ```
 
@@ -255,6 +256,42 @@ workspace-manager open --workspace "services/api"
 # Debug mode to see what's happening
 workspace-manager open --debug
 ```
+
+### Link Command
+
+Create relative symlinks inside configured submodules pointing at files or directories in the workspace root. Driven by a per-workspace `link` map in `workspace.yml`:
+
+```yaml
+workspaces:
+  - url: git@example.com:org/repo.git
+    path: projects/repo
+    branch: main
+    active: true
+    link:
+      .agents: .agents            # dir link
+      AGENT.md: prompt/BACKEND.md # file link
+```
+
+```bash
+workspace-manager link [options]
+```
+
+**Options:**
+
+- `-c, --config <file>` - Workspace config file (default: workspace.yml)
+- `-w, --workspace-root <path>` - Workspace root directory (default: .)
+- `-d, --debug` - Enable debug mode
+
+**Behavior:**
+
+1. **Two-phase execution** — validation runs first across all workspaces; no filesystem changes are made until everything validates.
+2. **All-or-nothing validation** — if any source is missing or any destination conflicts with a real directory, the entire run aborts with no mutations.
+3. **Interactive overwrite prompts** — when a destination already exists (real file, wrong symlink, or dangling symlink), you are prompted `y/N` before replacing it.
+4. **Relative symlinks** — links are created as relative paths, so the workspace remains portable.
+5. **Idempotent** — re-running `link` when symlinks are already correct is a no-op (silent, no prompts); already-correct links are counted toward `linkedCount`, so repeated runs report identical numbers.
+6. **Missing submodules are skipped** — workspaces that haven't been synced yet emit a warning and are skipped; they do not fail the run.
+
+> **Note:** `--yes` / non-interactive mode and sync-integration are planned for a future release.
 
 ### Add Command
 

--- a/docs/prds/link-command-v1.0-prd.md
+++ b/docs/prds/link-command-v1.0-prd.md
@@ -1,0 +1,191 @@
+# link-command - Product Requirements Document (PRD)
+
+## Requirements Description
+
+### Background
+
+- **Business Problem**: Developers using this multi-repo workspace CLI often need shared files/directories (e.g. `.agents/`, prompt files like `AGENT.md`) available inside each submodule. Manually copying them causes drift; manually creating symlinks is tedious and error-prone.
+- **Target Users**: Developers managing multi-repo workspaces with this CLI (Git submodules + optional `go.work`).
+- **Value Proposition**: Declarative, config-driven symlinking from workspace root into submodules — one command, idempotent, portable (relative links), safe (all-or-nothing validation).
+
+### Feature Overview
+
+- **Core Features**:
+  - New standalone CLI command: `link`
+  - New per-workspace config field `link`: a map of `destination → source`
+    - **Key**: path relative to the submodule root (the symlink to create)
+    - **Value**: path relative to the workspace root (the link target)
+  - Supports linking both **files and directories**
+  - Two-phase execution: validate everything first (all-or-nothing), then link
+  - Interactive overwrite confirmation (`y/N`) for conflicting destinations
+- **Feature Boundaries**:
+  - **In scope**: standalone `link` command; config schema extension; validation; interactive linking; summary output
+  - **Out of scope** (future): integration into the `sync` pipeline; `--yes`/non-interactive mode; link removal/unlink command; absolute symlink targets
+- **User Scenarios**:
+  - Sharing an `.agents/` directory from the workspace root into every submodule
+  - Giving each submodule its own `AGENT.md` pointing at a per-repo prompt file (e.g. `prompt/BACKEND.md`) in the workspace root
+
+Example config:
+
+```yaml
+workspaces:
+  - url: 'git@example.com:org1/repo1.git'
+    path: projects/repo1
+    branch: fake-branch1
+    isGolang: true
+    active: true
+    link:
+      .agents: .agents              # dir link: <submodule>/.agents -> <root>/.agents
+      AGENT.md: prompt/BACKEND.md   # file link: <submodule>/AGENT.md -> <root>/prompt/BACKEND.md
+```
+
+### Detailed Requirements
+
+- **Input/Output**:
+  - Input: `workspace.yml` (via standard config discovery), no command-specific flags for now (shared flags like `--config` / `--workspace-root` / `--debug` apply as usual)
+  - Output: colored console output per existing conventions; warning for skipped missing submodules; final summary, e.g. `✅ linked: 3, ⏭️  skipped: 1`
+- **User Interaction Flow**:
+  1. Load and validate `workspace.yml` (Zod schema extended with `link`)
+  2. Select workspaces: `active: true` AND `link` map present and non-empty
+  3. For each selected workspace, if the submodule directory does not exist on disk → print warning ("run `sync` to grab the missing submodule") and exclude that workspace from further processing
+  4. **Phase 1 — Validation (all-or-nothing)**, across all remaining workspaces and all their link entries:
+     - Path rules: keys and values must be non-empty, relative, and contain no `..` traversal → violations are `CONFIG_INVALID`
+     - Every source (value) must exist in the workspace root (file or directory)
+     - No destination (key) may be an existing **real directory** (a non-symlink directory) — the user must fix this manually
+     - If **any** check fails → report all violations, exit non-zero, create/modify nothing
+  5. **Phase 2 — Linking**, per entry:
+     - Destination is already a symlink pointing to the configured source → **silently skip** (idempotent, no log)
+     - Destination exists as a real file, or as a symlink pointing elsewhere → prompt `Overwrite? y/N`
+       - `y` → remove existing destination, create symlink
+       - `N` (default) → skip this entry, continue with the next
+     - Destination does not exist → create parent directories as needed (nested keys supported), create symlink
+  6. Print summary; exit 0 (user-skips are still success)
+- **Data Requirements**:
+  - Zod schema extension on `workspaceConfigItemSchema`: `link: z.record(z.string()).optional()`
+  - Path validation is a **domain rule** (pure functions in `domain/`): reject empty, absolute, and `..`-containing paths in both keys and values
+  - Symlink targets are **relative paths**, computed from the destination's parent directory to the source in the workspace root (e.g. `../../prompt/BACKEND.md`) — fully portable if the workspace folder is moved
+- **Edge Cases**:
+  - `active: false` workspace with a `link` map → ignored entirely
+  - Missing submodule directory → warning + skip workspace (not a validation failure)
+  - Nested key paths (e.g. `config/deep/AGENT.md`) → parent directories auto-created
+  - Source value pointing to a directory → directory symlink (supported)
+  - Destination already a correct symlink → silent skip (re-runs are no-ops)
+  - Destination is a broken/dangling symlink → treated as "incorrect link" → overwrite prompt
+  - User answers `N` (or just Enter) → skip, continue, still exit 0
+
+## Design Decisions
+
+### Technical Approach
+
+- **Architecture Choice**: Follow existing ports/adapters + service + thin cmd layering (AGENTS.md §3). Pure link-planning rules (path validation, relative target computation, entry classification: create / skip-correct / conflict-file / conflict-dir / missing-source) live in `domain/` as pure, testable functions.
+- **Key Components**:
+  - `src/domain/config-schema.ts` — extend with `link` field
+  - `src/domain/` (new module, e.g. `link-plan.ts`) — pure path validation + link-plan computation
+  - `src/ports/file-system.ts` — extend (or add port methods) for: `exists`, `isDirectory`, `lstat`/readlink, `createSymlink`, `remove`, `ensureDir` — only what is needed
+  - `src/services/link.ts` — new `LinkService` class: orchestrates discovery → filter → validate → prompt → link, returns `Result<T, AppError>`
+  - `src/cmds/link.ts` — thin Cliffy action: flags → service, prompts (Cliffy confirm), summary output, exit-code mapping
+  - Composition root wiring in `src/cli.ts` / composition module
+- **Data Storage**: `workspace.yml` only (no new state)
+- **Interface Design**: `deno run main.ts link [--config …] [--workspace-root …] [--debug]`; no new command-specific flags
+- **Error Handling**: `Result<T, AppError>` throughout; new error code suggested: `LINK_VALIDATION_FAILED` (aggregates all phase-1 violations in `context`); `CONFIG_INVALID` for schema/path-rule violations; `PATH_INVALID` reusable where appropriate. No `try/catch` in application code.
+- **Prompting**: Cliffy `Confirm` with default `No` (`y/N`); prompting is assumed always possible (non-interactive environments unsupported for now)
+
+### Constraints
+
+- **Performance Requirements**: Trivial scale (tens of entries); no concurrency requirement
+- **Compatibility**: Deno 2.4+; symlinks via `Deno.symlink`; relative-target computation must be correct for nested submodule paths (e.g. `projects/repo1`) and nested keys
+- **Security**: No absolute paths, no `..` traversal — links can never escape the workspace root or point outside the submodule
+- **Scalability**: Future sync-pipeline integration should only require calling `LinkService` from `SyncService` — design the service API to not assume an interactive cmd context (prompt decision injected as a dependency/port)
+
+### Risk Assessment
+
+- **Technical Risks**:
+  - Incorrect relative-path computation for deeply nested keys → mitigate with unit tests over path matrices (domain pure functions)
+  - Platform symlink differences (Windows) → out of scope; document Unix-like target
+- **Dependency Risks**: None new — uses existing Cliffy, Zod, std libs
+- **Schedule Risks**: Low; small, well-bounded feature
+
+## Acceptance Criteria
+
+### Functional Acceptance
+
+- [ ] `link` command runs standalone and reads `workspace.yml` via existing discovery rules
+- [ ] Workspaces with `active: false` are ignored even if they have a `link` map
+- [ ] Missing submodule directories produce a warning mentioning `sync` and are skipped
+- [ ] Phase 1 validates ALL entries before ANY link is created; any violation → non-zero exit, zero filesystem changes
+- [ ] Absolute paths, `..` traversal, and empty keys/values are rejected as `CONFIG_INVALID`
+- [ ] Existing real directory at a destination → validation failure (not a prompt)
+- [ ] Missing source in workspace root → validation failure
+- [ ] Existing real file or incorrect/dangling symlink at destination → `y/N` prompt; `y` replaces, `N` skips
+- [ ] Correct existing symlink → silently skipped (idempotent re-run produces no changes and no per-entry log)
+- [ ] Nested keys create parent directories automatically
+- [ ] Created symlinks use relative targets verifiable with `readlink`
+- [ ] Summary printed at end; user-skips exit 0
+
+### Quality Standards
+
+- [ ] Code Quality: `deno fmt` / `deno lint` clean; tabs, double quotes, braces everywhere; layering rules respected (no adapter imports in cmd/service, no `try/catch`)
+- [ ] Test Coverage: `Deno.test` unit tests with fakes covering: path validation rules, active filtering, missing-submodule skip, validation all-or-nothing, idempotent skip, overwrite y/N branches, nested parent creation, relative target computation
+- [ ] Performance Metrics: N/A (trivial)
+- [ ] Security Review: path-traversal rejection tested
+
+### User Acceptance
+
+- [ ] User Experience: output follows existing emoji/color conventions (✅ ⚠️ ❌ 💡); prompt defaults to `N`
+- [ ] Documentation: README.md updated with `link` command usage and config example
+- [ ] Training Materials: N/A
+
+## Execution Phases
+
+### Phase 1: Preparation
+
+**Goal**: Config schema and domain rules in place
+
+- [ ] Extend `workspaceConfigItemSchema` with `link: z.record(z.string()).optional()` + schema tests (valid/invalid)
+- [ ] Implement pure domain module: path validation + link-plan computation + tests
+- **Deliverables**: schema + domain module with passing unit tests
+- **Time**: ~0.5 day
+
+### Phase 2: Core Development
+
+**Goal**: Port methods, `LinkService`, and command
+
+- [ ] Extend filesystem port + adapter with needed primitives (symlink, lstat/readlink, remove, ensureDir)
+- [ ] Implement `LinkService` (discovery → filter → validate → link orchestration, `Result`-based)
+- [ ] Implement thin `src/cmds/link.ts` (prompts, summary, exit codes) and wire in composition root
+- **Deliverables**: working `link` command
+- **Time**: ~1 day
+
+### Phase 3: Integration & Testing
+
+**Goal**: Quality assurance
+
+- [ ] Service tests with fakes covering all acceptance criteria branches
+- [ ] Manual end-to-end test against a temp workspace with real git submodules
+- [ ] `deno fmt`, `deno lint`, full test suite green
+- **Deliverables**: verified feature
+- **Time**: ~0.5 day
+
+### Phase 4: Deployment
+
+**Goal**: Documentation and release readiness
+
+- [ ] Update README.md (usage + config example)
+- [ ] Note future work in docs/code comments: sync-pipeline integration, `--yes` flag, non-interactive mode
+- **Deliverables**: documented, mergeable PR
+- **Time**: ~0.25 day
+
+---
+
+## Clarification Summary
+
+| Round | Key Decisions |
+| ----- | ------------- |
+| 1 | Standalone command (sync integration deferred); skips `active: false`; relative symlink targets for portability; all-or-nothing source validation before linking |
+| 2 | Real directory at destination = hard validation failure (user fixes manually); already-correct links silently skipped; no `--yes`/non-interactive support; nested keys auto-create parents; `..` rejected |
+| 3 | Missing submodule = warning + skip (suggest `sync`), not a validation failure; absolute paths/empty keys also rejected; summary printed; user-skips exit 0, only validation failures exit non-zero |
+
+**Document Version**: 1.0
+**Created**: 2025-01-01
+**Clarification Rounds**: 3
+**Quality Score**: 92/100

--- a/example/workspace.yml
+++ b/example/workspace.yml
@@ -24,6 +24,9 @@ workspaces:
     branch: develop
     isGolang: true
     active: true
+    link:
+      .agents: .agents
+      AGENT.md: prompt/BACKEND.md
     postSyncHooks:
       - cmd: ["go", "mod", "tidy"]
         description: "Clean up Go dependencies"

--- a/src/adapters/confirmer.ts
+++ b/src/adapters/confirmer.ts
@@ -1,0 +1,17 @@
+import { Confirm } from "@cliffy/prompt";
+import { Result } from "typescript-result";
+import { AppError, AppErrorCode } from "../libs/app-error.ts";
+import type { Confirmer } from "../ports/confirmer.ts";
+
+export class CliffyConfirmer implements Confirmer {
+	async confirm(message: string): Promise<Result<boolean, AppError>> {
+		return await Result.fromAsyncCatching(async () => {
+			return await Confirm.prompt({ message, default: false });
+		}).mapError((error) => {
+			if (error instanceof Error && error.message.includes("aborted")) {
+				return new AppError(AppErrorCode.CANCELLED, "user cancelled confirmation", { cause: error });
+			}
+			return new AppError(AppErrorCode.INTERNAL, "confirmation prompt failed", { cause: error });
+		});
+	}
+}

--- a/src/adapters/file-system.ts
+++ b/src/adapters/file-system.ts
@@ -34,6 +34,39 @@ export class DenoFileSystem implements FileSystemPort {
 			(error) => new AppError(AppErrorCode.INTERNAL, `Failed to check if directory is empty`, { cause: error }),
 		);
 	}
+
+	async lstat(path: string): Promise<Result<{ isDirectory: boolean; isSymlink: boolean }, AppError>> {
+		return await Result.fromAsyncCatching(() => Deno.lstat(path)).mapError(
+			(error) => new AppError(AppErrorCode.FS_FAILED, `lstat failed: ${path}`, { cause: error }),
+		).map((stat) => ({
+			isDirectory: stat.isDirectory,
+			isSymlink: stat.isSymlink,
+		}));
+	}
+
+	async readLink(path: string): Promise<Result<string, AppError>> {
+		return await Result.fromAsyncCatching(() => Deno.readLink(path)).mapError(
+			(error) => new AppError(AppErrorCode.FS_FAILED, `readLink failed: ${path}`, { cause: error }),
+		);
+	}
+
+	async createSymlink(target: string, linkPath: string): Promise<Result<void, AppError>> {
+		return await Result.fromAsyncCatching(() => Deno.symlink(target, linkPath)).mapError(
+			(error) => new AppError(AppErrorCode.FS_FAILED, `createSymlink failed: ${linkPath}`, { cause: error }),
+		);
+	}
+
+	async remove(path: string): Promise<Result<void, AppError>> {
+		return await Result.fromAsyncCatching(() => Deno.remove(path)).mapError(
+			(error) => new AppError(AppErrorCode.FS_FAILED, `remove failed: ${path}`, { cause: error }),
+		);
+	}
+
+	async ensureDir(path: string): Promise<Result<void, AppError>> {
+		return await Result.fromAsyncCatching(() => Deno.mkdir(path, { recursive: true })).mapError(
+			(error) => new AppError(AppErrorCode.FS_FAILED, `ensureDir failed: ${path}`, { cause: error }),
+		);
+	}
 }
 
 const defaultFileSystem = new DenoFileSystem();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,7 @@ import { syncCommand } from "./cmds/sync.ts";
 import { updateCommand } from "./cmds/update.ts";
 import { createAppContext } from "./composition.ts";
 import { CommandErrorHandler } from "./libs/command-error-handler.ts";
+import { linkCommand } from "./cmds/link.ts";
 
 // Create CLI application
 export const cli = new Command()
@@ -209,6 +210,22 @@ cli
 			workspace: options.workspace,
 		});
 		CommandErrorHandler.withExit(result, "Open", { debug: options.debug });
+	});
+
+// Link command
+cli
+	.command("link", "Create symlinks from workspace root files into submodules")
+	.option("-c, --config <config:string>", "Workspace config file (auto-discovers if not specified)")
+	.option("-w, --workspace-root <workspace-root:string>", "Workspace root directory (auto-discovers if not specified)")
+	.option("-d, --debug", "Enable debug mode", { default: false })
+	.action(async (options) => {
+		const ctx = createAppContext({ debug: options.debug });
+		const result = await linkCommand(ctx, {
+			config: options.config,
+			workspaceRoot: options.workspaceRoot,
+			debug: options.debug,
+		});
+		CommandErrorHandler.withExit(result, "Link", { debug: options.debug });
 	});
 
 // Completions command

--- a/src/cmds/link.ts
+++ b/src/cmds/link.ts
@@ -1,0 +1,46 @@
+import { green, red, yellow } from "@std/fmt/colors";
+import { Result } from "typescript-result";
+import type { AppContext } from "../composition.ts";
+import { AppError, AppErrorCode } from "../libs/app-error.ts";
+import type { LinkReport } from "../services/link.ts";
+
+export type LinkCommandOption = {
+	config?: string;
+	workspaceRoot?: string;
+	debug?: boolean;
+};
+
+export async function linkCommand(ctx: AppContext, options: LinkCommandOption): Promise<Result<void, AppError>> {
+	const result = await ctx.linkService.run({
+		config: options.config,
+		workspaceRoot: options.workspaceRoot,
+		debug: options.debug,
+	});
+
+	if (!result.ok) {
+		if (result.error.code === AppErrorCode.LINK_VALIDATION_FAILED) {
+			const violations = result.error.context?.violations as string[] | undefined;
+			if (violations) {
+				for (const violation of violations) {
+					console.error(red(`❌ ${violation}`));
+				}
+			}
+		}
+		return Result.error(result.error);
+	}
+
+	presentLinkReport(result.value);
+	return Result.ok();
+}
+
+function presentLinkReport(report: LinkReport): void {
+	console.log(green(`📄 Config file: ${report.configPath}`));
+	console.log(green(`📁 Workspace root: ${report.workspaceRoot}`));
+	console.log(green(`✅ linked: ${report.linkedCount}, ⏭️  skipped: ${report.skippedCount}`));
+
+	if (report.skippedWorkspaceCount > 0) {
+		console.log(
+			yellow(`💡 ${report.skippedWorkspaceCount} workspace(s) were not linked because the submodule was missing. Run \`sync\` first.`),
+		);
+	}
+}

--- a/src/composition.ts
+++ b/src/composition.ts
@@ -4,6 +4,7 @@ import { GitManager } from "./adapters/git.ts";
 import { GoWork } from "./adapters/go-work.ts";
 import { HookExecutor } from "./adapters/hooks.ts";
 import { WorkspaceDiscovery } from "./adapters/workspace-discovery.ts";
+import { CliffyConfirmer } from "./adapters/confirmer.ts";
 import type { ConfigStore } from "./ports/config-store.ts";
 import type { FileSystemPort } from "./ports/file-system.ts";
 import type { GitPortFactory } from "./ports/git.ts";
@@ -12,6 +13,7 @@ import type { HookRunner } from "./ports/hook-runner.ts";
 import type { WorkspaceDiscoveryOptions, WorkspaceDiscoveryPort } from "./ports/workspace-discovery.ts";
 import { AddService } from "./services/add.ts";
 import { EnableService } from "./services/enable.ts";
+import { LinkService } from "./services/link.ts";
 import { OpenService } from "./services/open.ts";
 import { SaveService } from "./services/save.ts";
 import { StatusService } from "./services/status.ts";
@@ -40,6 +42,7 @@ export type AppContext = {
 	addService: AddService;
 	enableService: EnableService;
 	openService: OpenService;
+	linkService: LinkService;
 };
 
 export function createAppContext(options?: BootstrapOptions): AppContext {
@@ -104,6 +107,13 @@ export function createAppContext(options?: BootstrapOptions): AppContext {
 		createHookRunner,
 	});
 
+	const linkService = new LinkService({
+		createDiscovery,
+		createConfigStore,
+		fileSystem,
+		confirmer: new CliffyConfirmer(),
+	});
+
 	return {
 		debug,
 		fileSystem,
@@ -120,5 +130,6 @@ export function createAppContext(options?: BootstrapOptions): AppContext {
 		addService,
 		enableService,
 		openService,
+		linkService,
 	};
 }

--- a/src/composition_test.ts
+++ b/src/composition_test.ts
@@ -39,6 +39,9 @@ Deno.test("createAppContext exposes all use-case services", () => {
 	assert(ctx.openService instanceof Object);
 	assert(typeof ctx.openService.listWorkspaces === "function");
 	assert(typeof ctx.openService.prepareWorkspace === "function");
+
+	assert(ctx.linkService instanceof Object);
+	assert(typeof ctx.linkService.run === "function");
 });
 
 Deno.test("gitFactory returns an object assignable to GitPort", () => {

--- a/src/domain/config-schema.ts
+++ b/src/domain/config-schema.ts
@@ -17,6 +17,7 @@ export const workspaceConfigItemSchema = z.object({
 	isGolang: z.boolean(),
 	active: z.boolean(),
 	postSyncHooks: z.array(postSyncHookSchema).optional(),
+	link: z.record(z.string()).optional(),
 });
 
 export const workspaceConfigSchema = z.object({

--- a/src/domain/config-schema_test.ts
+++ b/src/domain/config-schema_test.ts
@@ -137,3 +137,62 @@ Deno.test("valid optional hook fields are accepted", () => {
 	assertEquals(result.value.workspaces[0].postSyncHooks?.length, 1);
 	assertEquals(result.value.hooks?.postSyncHooks?.length, 1);
 });
+
+Deno.test("TC-104: workspace item with valid link map parses", () => {
+	const raw = {
+		workspaces: [{
+			url: "git@example.com:org/repo.git",
+			path: "projects/repo",
+			branch: "main",
+			isGolang: false,
+			active: true,
+			link: { ".agents": ".agents", "AGENT.md": "prompt/BACKEND.md" },
+		}],
+	};
+
+	const result = parseWorkspaceConfig(raw);
+
+	assert(result.ok);
+	if (result.ok) {
+		assertEquals(result.value.workspaces[0].link, { ".agents": ".agents", "AGENT.md": "prompt/BACKEND.md" });
+	}
+});
+
+Deno.test("TC-104: non-string values in link map are rejected", () => {
+	const raw = {
+		workspaces: [{
+			url: "git@example.com:org/repo.git",
+			path: "projects/repo",
+			branch: "main",
+			isGolang: false,
+			active: true,
+			link: { "a": 1 },
+		}],
+	};
+
+	const result = parseWorkspaceConfig(raw);
+
+	assertFalse(result.ok);
+	if (!result.ok) {
+		assertEquals(result.error.code, AppErrorCode.CONFIG_INVALID);
+	}
+});
+
+Deno.test("TC-104: missing link field still parses (optional)", () => {
+	const raw = {
+		workspaces: [{
+			url: "git@example.com:org/repo.git",
+			path: "projects/repo",
+			branch: "main",
+			isGolang: false,
+			active: true,
+		}],
+	};
+
+	const result = parseWorkspaceConfig(raw);
+
+	assert(result.ok);
+	if (result.ok) {
+		assertEquals(result.value.workspaces[0].link, undefined);
+	}
+});

--- a/src/domain/link-plan.ts
+++ b/src/domain/link-plan.ts
@@ -1,0 +1,105 @@
+import * as path from "@std/path";
+import { Result } from "typescript-result";
+import { AppError, AppErrorCode } from "../libs/app-error.ts";
+import type { WorkspaceConfig, WorkspaceConfigItem } from "../types/config.ts";
+
+export type LinkEntry = {
+	workspacePath: string;
+	key: string;
+	value: string;
+	destination: string;
+	source: string;
+	target: string;
+};
+
+/**
+ * Validate a single link path (key or value).
+ * Rejects: empty/whitespace-only, absolute paths, any segment equal to `..`.
+ */
+export function validateLinkPath(p: string): Result<void, AppError> {
+	const trimmed = p.trim();
+	if (trimmed.length === 0) {
+		return Result.error(
+			new AppError(AppErrorCode.CONFIG_INVALID, "link path must not be empty or whitespace-only", { context: { path: p } }),
+		);
+	}
+
+	if (path.isAbsolute(p)) {
+		return Result.error(
+			new AppError(AppErrorCode.CONFIG_INVALID, "link path must not be absolute", { context: { path: p } }),
+		);
+	}
+
+	// Reject Windows-style absolute paths (e.g. "C:\foo") on all platforms.
+	if (/^[a-zA-Z]:[\\/]/.test(p)) {
+		return Result.error(
+			new AppError(AppErrorCode.CONFIG_INVALID, "link path must not be absolute", { context: { path: p } }),
+		);
+	}
+
+	// Split on both / and \ to catch Windows-style paths too
+	const segments = p.split(/[\/\\]/);
+	for (const segment of segments) {
+		if (segment === "..") {
+			return Result.error(
+				new AppError(AppErrorCode.CONFIG_INVALID, "link path must not contain '..' segments", { context: { path: p } }),
+			);
+		}
+	}
+
+	return Result.ok();
+}
+
+/**
+ * Validate every key and value in a link map. Fails fast on first violation.
+ */
+export function validateLinkMap(link: Record<string, string>): Result<void, AppError> {
+	for (const key of Object.keys(link)) {
+		const keyResult = validateLinkPath(key);
+		if (!keyResult.ok) {
+			return Result.error(keyResult.error);
+		}
+	}
+
+	for (const value of Object.values(link)) {
+		const valueResult = validateLinkPath(value);
+		if (!valueResult.ok) {
+			return Result.error(valueResult.error);
+		}
+	}
+
+	return Result.ok();
+}
+
+/**
+ * Filter workspaces that are active AND have a non-empty link map.
+ */
+export function getLinkableWorkspaces(config: WorkspaceConfig): WorkspaceConfigItem[] {
+	return config.workspaces.filter((item) => item.active && item.link && Object.keys(item.link).length > 0);
+}
+
+/**
+ * Build link entries for a single workspace.
+ * Computes absolute source/destination and relative symlink target.
+ */
+export function buildLinkEntries(workspaceRoot: string, workspace: WorkspaceConfigItem): LinkEntry[] {
+	const linkMap = workspace.link ?? {};
+	const entries: LinkEntry[] = [];
+
+	for (const [key, value] of Object.entries(linkMap)) {
+		const destination = path.join(workspaceRoot, workspace.path, key);
+		const source = path.join(workspaceRoot, value);
+		const target = path.relative(path.dirname(destination), source);
+
+		entries.push({
+			workspacePath: workspace.path,
+			key,
+			value,
+			destination,
+			source,
+			target,
+		});
+	}
+
+	return entries;
+}

--- a/src/domain/link-plan_test.ts
+++ b/src/domain/link-plan_test.ts
@@ -1,0 +1,82 @@
+import { assert, assertEquals, assertFalse } from "@std/assert";
+import { AppErrorCode } from "../libs/app-error.ts";
+import { buildLinkEntries, getLinkableWorkspaces, validateLinkMap, validateLinkPath } from "./link-plan.ts";
+import type { WorkspaceConfig, WorkspaceConfigItem } from "../types/config.ts";
+
+Deno.test("TC-101: validateLinkPath rejects unsafe paths", () => {
+	const unsafe = ["", "   ", "/etc/passwd", "../outside", "a/../../b", "C:\\abs"];
+	for (const p of unsafe) {
+		const result = validateLinkPath(p);
+		assertFalse(result.ok, `expected error for path: ${JSON.stringify(p)}`);
+		if (!result.ok) {
+			assertEquals(result.error.code, AppErrorCode.CONFIG_INVALID);
+		}
+	}
+});
+
+Deno.test("TC-101: validateLinkPath accepts safe relative paths", () => {
+	const safe = [".agents", "AGENT.md", "config/deep/AGENT.md", "a/./b"];
+	for (const p of safe) {
+		const result = validateLinkPath(p);
+		assert(result.ok, `expected ok for path: ${JSON.stringify(p)}`);
+	}
+});
+
+Deno.test("TC-102: getLinkableWorkspaces filters active workspaces with non-empty link map", () => {
+	const config: WorkspaceConfig = {
+		workspaces: [
+			{ url: "git@example.com:a/r1.git", path: "projects/r1", branch: "main", isGolang: false, active: true, link: { ".agents": ".agents" } },
+			{ url: "git@example.com:a/r2.git", path: "projects/r2", branch: "main", isGolang: false, active: true },
+			{ url: "git@example.com:a/r3.git", path: "projects/r3", branch: "main", isGolang: false, active: true, link: {} },
+			{ url: "git@example.com:a/r4.git", path: "projects/r4", branch: "main", isGolang: false, active: false, link: { "x": "y" } },
+		],
+	};
+
+	const linkable = getLinkableWorkspaces(config);
+
+	assertEquals(linkable.length, 1);
+	assertEquals(linkable[0].path, "projects/r1");
+});
+
+Deno.test("TC-103: buildLinkEntries computes correct relative targets", () => {
+	const workspace: WorkspaceConfigItem = {
+		url: "git@example.com:org/repo.git",
+		path: "projects/repo1",
+		branch: "main",
+		isGolang: false,
+		active: true,
+		link: {
+			"AGENT.md": "prompt/BACKEND.md",
+			".agents": ".agents",
+			"config/deep/AGENT.md": "prompt/BACKEND.md",
+		},
+	};
+
+	const entries = buildLinkEntries("/ws", workspace);
+
+	assertEquals(entries.length, 3);
+
+	const agentMd = entries.find((e) => e.key === "AGENT.md")!;
+	assertEquals(agentMd.source, "/ws/prompt/BACKEND.md");
+	assertEquals(agentMd.destination, "/ws/projects/repo1/AGENT.md");
+	assertEquals(agentMd.target, "../../prompt/BACKEND.md");
+
+	const agentsDir = entries.find((e) => e.key === ".agents")!;
+	assertEquals(agentsDir.target, "../../.agents");
+
+	const deep = entries.find((e) => e.key === "config/deep/AGENT.md")!;
+	assertEquals(deep.target, "../../../../prompt/BACKEND.md");
+});
+
+Deno.test("validateLinkMap rejects first violation and fails fast", () => {
+	const result = validateLinkMap({ ".agents": "/absolute/path" });
+	assertFalse(result.ok);
+	if (!result.ok) {
+		assertEquals(result.error.code, AppErrorCode.CONFIG_INVALID);
+	}
+});
+
+Deno.test("validateLinkMap accepts valid map", () => {
+	const result = validateLinkMap({ ".agents": ".agents", "AGENT.md": "prompt/BACKEND.md" });
+	assert(result.ok);
+});

--- a/src/libs/app-error.ts
+++ b/src/libs/app-error.ts
@@ -18,6 +18,8 @@ export const AppErrorCode = {
 	CANCELLED: "CANCELLED",
 	INVALID_INPUT: "INVALID_INPUT",
 	INTERNAL: "INTERNAL",
+	FS_FAILED: "FS_FAILED",
+	LINK_VALIDATION_FAILED: "LINK_VALIDATION_FAILED",
 } as const;
 
 export type AppErrorCode = (typeof AppErrorCode)[keyof typeof AppErrorCode];

--- a/src/ports/confirmer.ts
+++ b/src/ports/confirmer.ts
@@ -1,0 +1,6 @@
+import type { Result } from "typescript-result";
+import type { AppError } from "../libs/app-error.ts";
+
+export type Confirmer = {
+	confirm(message: string): Promise<Result<boolean, AppError>>;
+};

--- a/src/ports/file-system.ts
+++ b/src/ports/file-system.ts
@@ -4,4 +4,9 @@ import type { AppError } from "../libs/app-error.ts";
 export type FileSystemPort = {
 	isDir(path: string): Promise<Result<void, AppError>>;
 	isDirectoryEmpty(path: string): Promise<Result<boolean, AppError>>;
+	lstat(path: string): Promise<Result<{ isDirectory: boolean; isSymlink: boolean }, AppError>>;
+	readLink(path: string): Promise<Result<string, AppError>>;
+	createSymlink(target: string, linkPath: string): Promise<Result<void, AppError>>;
+	remove(path: string): Promise<Result<void, AppError>>;
+	ensureDir(path: string): Promise<Result<void, AppError>>;
 };

--- a/src/services/link.ts
+++ b/src/services/link.ts
@@ -1,0 +1,196 @@
+import * as path from "@std/path";
+import { Result } from "typescript-result";
+import { AppError, AppErrorCode } from "../libs/app-error.ts";
+import { buildLinkEntries, getLinkableWorkspaces, validateLinkMap } from "../domain/link-plan.ts";
+import { workspaceDirectory } from "../domain/workspaces.ts";
+import { yellow } from "@std/fmt/colors";
+import type { ConfigStore } from "../ports/config-store.ts";
+import type { Confirmer } from "../ports/confirmer.ts";
+import type { FileSystemPort } from "../ports/file-system.ts";
+import type { WorkspaceDiscoveryOptions, WorkspaceDiscoveryPort } from "../ports/workspace-discovery.ts";
+
+export type LinkReport = {
+	workspaceRoot: string;
+	configPath: string;
+	linkedCount: number;
+	skippedCount: number;
+	skippedWorkspaceCount: number;
+};
+
+export type LinkServiceDeps = {
+	createDiscovery(options: WorkspaceDiscoveryOptions): WorkspaceDiscoveryPort;
+	createConfigStore(configPath: string): ConfigStore;
+	fileSystem: FileSystemPort;
+	confirmer: Confirmer;
+};
+
+export type LinkInput = {
+	config?: string;
+	workspaceRoot?: string;
+	debug?: boolean;
+};
+
+export class LinkService {
+	constructor(private readonly deps: LinkServiceDeps) {}
+
+	async run(input: LinkInput): Promise<Result<LinkReport, AppError>> {
+		const discovery = this.deps.createDiscovery({
+			config: input.config,
+			workspaceRoot: input.workspaceRoot,
+		});
+
+		const discoverResult = await discovery.discover();
+		if (!discoverResult.ok) {
+			return Result.error(discoverResult.error);
+		}
+
+		const { workspaceRoot, configPath } = discoverResult.value;
+
+		const configStore = this.deps.createConfigStore(configPath);
+		const configResult = await configStore.getWorkspaceConfig(workspaceRoot);
+		if (!configResult.ok) {
+			return Result.error(configResult.error);
+		}
+		const config = configResult.value;
+
+		const linkableWorkspaces = getLinkableWorkspaces(config);
+		if (linkableWorkspaces.length === 0) {
+			return Result.ok({
+				workspaceRoot,
+				configPath,
+				linkedCount: 0,
+				skippedCount: 0,
+				skippedWorkspaceCount: 0,
+			});
+		}
+
+		// Filter out workspaces whose submodule directory is missing
+		const presentWorkspaces: typeof linkableWorkspaces = [];
+		let skippedWorkspaceCount = 0;
+
+		for (const workspace of linkableWorkspaces) {
+			const workspaceDir = workspaceDirectory(workspaceRoot, workspace.path);
+			const dirCheck = await this.deps.fileSystem.isDir(workspaceDir);
+			if (!dirCheck.ok) {
+				console.log(
+					yellow(`⚠️  Submodule not found: ${workspace.path} — run \`sync\` to grab the missing submodule. Skipping.`),
+				);
+				skippedWorkspaceCount++;
+				continue;
+			}
+			presentWorkspaces.push(workspace);
+		}
+
+		if (presentWorkspaces.length === 0) {
+			return Result.ok({
+				workspaceRoot,
+				configPath,
+				linkedCount: 0,
+				skippedCount: 0,
+				skippedWorkspaceCount,
+			});
+		}
+
+		// Pre-validate all link maps before any FS operations (config-level errors fail fast)
+		for (const workspace of presentWorkspaces) {
+			const mapResult = validateLinkMap(workspace.link ?? {});
+			if (!mapResult.ok) {
+				return Result.error(mapResult.error); // CONFIG_INVALID
+			}
+		}
+
+		// Phase 1 — all-or-nothing FS validation
+		type EntryWithWorkspace = { workspace: typeof presentWorkspaces[number]; entries: import("../domain/link-plan.ts").LinkEntry[] };
+		const allEntries: EntryWithWorkspace[] = [];
+		const violations: string[] = [];
+
+		for (const workspace of presentWorkspaces) {
+			const entries = buildLinkEntries(workspaceRoot, workspace);
+			for (const entry of entries) {
+				// Source must exist
+				const sourceStat = await this.deps.fileSystem.lstat(entry.source);
+				if (!sourceStat.ok) {
+					violations.push(`${workspace.path}: ${entry.key} -> ${entry.value}: source not found`);
+					continue;
+				}
+
+				// Destination: if it exists and is a real directory (not symlink), violation
+				const destStat = await this.deps.fileSystem.lstat(entry.destination);
+				if (destStat.ok && destStat.value.isDirectory && !destStat.value.isSymlink) {
+					violations.push(`${workspace.path}: ${entry.key} -> ${entry.value}: real directory conflict at destination`);
+				}
+			}
+
+			allEntries.push({ workspace, entries });
+		}
+
+		if (violations.length > 0) {
+			return Result.error(
+				new AppError(
+					AppErrorCode.LINK_VALIDATION_FAILED,
+					`Link validation failed: ${violations.length} violation(s) found. Nothing was modified.`,
+					{ context: { violations } },
+				),
+			);
+		}
+
+		// Phase 2 — linking
+		let linkedCount = 0;
+		let skippedCount = 0;
+
+		for (const { entries } of allEntries) {
+			for (const entry of entries) {
+				const destStat = await this.deps.fileSystem.lstat(entry.destination);
+
+				if (destStat.ok) {
+					if (destStat.value.isSymlink) {
+						// Read the symlink target and compare
+						const readResult = await this.deps.fileSystem.readLink(entry.destination);
+						if (readResult.ok) {
+							const existingTarget = path.normalize(readResult.value);
+							const expectedTarget = path.normalize(entry.target);
+							if (existingTarget === expectedTarget) {
+								// Already correct — count it (idempotent)
+								linkedCount++;
+								continue;
+							}
+						}
+						// Wrong target or read failed — treat as conflict
+					}
+					// Real file, wrong symlink, or dangling symlink — prompt
+					const confirmResult = await this.deps.confirmer.confirm(`Overwrite ${entry.destination}?`);
+					if (!confirmResult.ok) {
+						return Result.error(confirmResult.error);
+					}
+					if (!confirmResult.value) {
+						skippedCount++;
+						continue;
+					}
+					const removeResult = await this.deps.fileSystem.remove(entry.destination);
+					if (!removeResult.ok) {
+						return Result.error(removeResult.error);
+					}
+				}
+				// Destination missing (or just removed) — create
+				const parentDir = path.dirname(entry.destination);
+				const ensureResult = await this.deps.fileSystem.ensureDir(parentDir);
+				if (!ensureResult.ok) {
+					return Result.error(ensureResult.error);
+				}
+				const linkResult = await this.deps.fileSystem.createSymlink(entry.target, entry.destination);
+				if (!linkResult.ok) {
+					return Result.error(linkResult.error);
+				}
+				linkedCount++;
+			}
+		}
+
+		return Result.ok({
+			workspaceRoot,
+			configPath,
+			linkedCount,
+			skippedCount,
+			skippedWorkspaceCount,
+		});
+	}
+}

--- a/src/services/link_test.ts
+++ b/src/services/link_test.ts
@@ -1,0 +1,474 @@
+import { assert, assertEquals, assertFalse } from "@std/assert";
+import { Result } from "typescript-result";
+import { AppErrorCode, isAppError } from "../libs/app-error.ts";
+import { type LinkInput, type LinkReport, LinkService } from "./link.ts";
+import { FakeConfigStore, FakeConfirmer, FakeDiscovery, FakeFileSystem, type FakeFsEntry } from "../testing/fakes.ts";
+import type { WorkspaceConfig } from "../types/config.ts";
+
+function makeDeps(fs: FakeFileSystem, confirmer: FakeConfirmer, config: WorkspaceConfig): {
+	deps: ConstructorParameters<typeof LinkService>[0];
+	run: (input?: Partial<LinkInput>) => Promise<Result<LinkReport, unknown>>;
+} {
+	const discovery = new FakeDiscovery(Result.ok({ workspaceRoot: "/ws", configPath: "/ws/workspace.yml" }));
+	const configStore = new FakeConfigStore("/ws/workspace.yml", config);
+
+	const deps = {
+		createDiscovery: () => discovery,
+		createConfigStore: () => configStore,
+		fileSystem: fs,
+		confirmer,
+	};
+
+	const service = new LinkService(deps);
+
+	return {
+		deps,
+		run: async (input?: Partial<LinkInput>) => {
+			const result = await service.run({ ...input });
+			// Widen type for test assertions
+			return result as Result<LinkReport, unknown>;
+		},
+	};
+}
+
+Deno.test("TC-201: happy path — create file and directory links", async () => {
+	const fs = new FakeFileSystem(
+		new Map<string, FakeFsEntry>([
+			["/ws", { kind: "dir" }],
+			["/ws/projects/repo1", { kind: "dir" }],
+			["/ws/.agents", { kind: "dir" }],
+			["/ws/prompt/BACKEND.md", { kind: "file" }],
+		]),
+	);
+
+	const confirmer = new FakeConfirmer([]);
+
+	const config: WorkspaceConfig = {
+		workspaces: [
+			{
+				url: "git@example.com:a/r1.git",
+				path: "projects/repo1",
+				branch: "main",
+				isGolang: false,
+				active: true,
+				link: {
+					".agents": ".agents",
+					"AGENT.md": "prompt/BACKEND.md",
+					"config/deep/AGENT.md": "prompt/BACKEND.md",
+				},
+			},
+		],
+	};
+
+	const { run } = makeDeps(fs, confirmer, config);
+	const result = await run();
+
+	assert(result.ok);
+	if (result.ok) {
+		assertEquals(result.value.linkedCount, 3);
+		assertEquals(result.value.skippedCount, 0);
+	}
+
+	// Inspect createSymlink calls
+	const symlinkCalls = fs.calls.filter((c) => c.method === "createSymlink");
+	assertEquals(symlinkCalls.length, 3);
+
+	const targets = symlinkCalls.map((c) => c.args[0] as string);
+	assert(targets.includes("../../.agents"));
+	assert(targets.includes("../../prompt/BACKEND.md"));
+	assert(targets.includes("../../../../prompt/BACKEND.md"));
+
+	// ensureDir called for config/deep parent
+	const ensureDirCalls = fs.calls.filter((c) => c.method === "ensureDir");
+	assert(ensureDirCalls.length >= 1);
+
+	// No confirm calls
+	assertEquals(confirmer.messages.length, 0);
+});
+
+Deno.test("TC-202: all-or-nothing — one missing source aborts everything", async () => {
+	const fs = new FakeFileSystem(
+		new Map<string, FakeFsEntry>([
+			["/ws", { kind: "dir" }],
+			["/ws/projects/repo1", { kind: "dir" }],
+			["/ws/projects/repo2", { kind: "dir" }],
+			// /ws/prompt/BACKEND.md exists (for repo1)
+			["/ws/prompt/BACKEND.md", { kind: "file" }],
+			// repo2 source is MISSING
+		]),
+	);
+
+	const confirmer = new FakeConfirmer([]);
+
+	const config: WorkspaceConfig = {
+		workspaces: [
+			{
+				url: "git@example.com:a/r1.git",
+				path: "projects/repo1",
+				branch: "main",
+				isGolang: false,
+				active: true,
+				link: { "AGENT.md": "prompt/BACKEND.md" },
+			},
+			{
+				url: "git@example.com:a/r2.git",
+				path: "projects/repo2",
+				branch: "main",
+				isGolang: false,
+				active: true,
+				link: { "AGENT.md": "missing/source.md" },
+			},
+		],
+	};
+
+	const { run } = makeDeps(fs, confirmer, config);
+	const result = await run();
+
+	assertFalse(result.ok);
+	if (!result.ok) {
+		assert(isAppError(result.error));
+		assertEquals(result.error.code, AppErrorCode.LINK_VALIDATION_FAILED);
+		const violations = result.error.context?.violations as string[] | undefined;
+		assert(violations !== undefined);
+		assert(violations.length > 0);
+	}
+
+	// No mutations
+	const mutatingCalls = fs.calls.filter((c) => ["createSymlink", "remove", "ensureDir"].includes(c.method));
+	assertEquals(mutatingCalls.length, 0);
+});
+
+Deno.test("TC-203: real directory at destination aborts run", async () => {
+	const fs = new FakeFileSystem(
+		new Map<string, FakeFsEntry>([
+			["/ws", { kind: "dir" }],
+			["/ws/projects/repo1", { kind: "dir" }],
+			["/ws/projects/repo1/.agents", { kind: "dir" }], // real dir at destination
+			["/ws/.agents", { kind: "dir" }], // source exists
+		]),
+	);
+
+	const confirmer = new FakeConfirmer([]);
+
+	const config: WorkspaceConfig = {
+		workspaces: [
+			{
+				url: "git@example.com:a/r1.git",
+				path: "projects/repo1",
+				branch: "main",
+				isGolang: false,
+				active: true,
+				link: { ".agents": ".agents" },
+			},
+		],
+	};
+
+	const { run } = makeDeps(fs, confirmer, config);
+	const result = await run();
+
+	assertFalse(result.ok);
+	if (!result.ok) {
+		assert(isAppError(result.error));
+		assertEquals(result.error.code, AppErrorCode.LINK_VALIDATION_FAILED);
+	}
+
+	// No mutations, no confirm calls
+	const mutatingCalls = fs.calls.filter((c) => ["createSymlink", "remove", "ensureDir"].includes(c.method));
+	assertEquals(mutatingCalls.length, 0);
+	assertEquals(confirmer.messages.length, 0);
+});
+
+Deno.test("TC-204: conflicting real file — user confirms overwrite", async () => {
+	const fs = new FakeFileSystem(
+		new Map<string, FakeFsEntry>([
+			["/ws", { kind: "dir" }],
+			["/ws/projects/repo1", { kind: "dir" }],
+			["/ws/projects/repo1/AGENT.md", { kind: "file" }], // real file at destination
+			["/ws/prompt/BACKEND.md", { kind: "file" }], // source exists
+		]),
+	);
+
+	const confirmer = new FakeConfirmer([true]);
+
+	const config: WorkspaceConfig = {
+		workspaces: [
+			{
+				url: "git@example.com:a/r1.git",
+				path: "projects/repo1",
+				branch: "main",
+				isGolang: false,
+				active: true,
+				link: { "AGENT.md": "prompt/BACKEND.md" },
+			},
+		],
+	};
+
+	const { run } = makeDeps(fs, confirmer, config);
+	const result = await run();
+
+	assert(result.ok);
+	if (result.ok) {
+		assertEquals(result.value.linkedCount, 1);
+		assertEquals(result.value.skippedCount, 0);
+	}
+
+	// remove called before createSymlink
+	const removeCalls = fs.calls.filter((c) => c.method === "remove");
+	assertEquals(removeCalls.length, 1);
+	assertEquals(removeCalls[0].args[0], "/ws/projects/repo1/AGENT.md");
+
+	// Confirm message mentions destination
+	assert(confirmer.messages.length > 0);
+	assert(confirmer.messages[0].includes("AGENT.md"));
+});
+
+Deno.test("TC-205: conflicting real file — user declines", async () => {
+	const fs = new FakeFileSystem(
+		new Map<string, FakeFsEntry>([
+			["/ws", { kind: "dir" }],
+			["/ws/projects/repo1", { kind: "dir" }],
+			["/ws/projects/repo1/AGENT.md", { kind: "file" }], // first entry: real file conflict
+			// OTHER.md destination does NOT exist (missing)
+			["/ws/prompt/BACKEND.md", { kind: "file" }],
+			["/ws/other/source.md", { kind: "file" }],
+		]),
+	);
+
+	const confirmer = new FakeConfirmer([false]);
+
+	const config: WorkspaceConfig = {
+		workspaces: [
+			{
+				url: "git@example.com:a/r1.git",
+				path: "projects/repo1",
+				branch: "main",
+				isGolang: false,
+				active: true,
+				link: {
+					"AGENT.md": "prompt/BACKEND.md", // conflicts → user declines
+					"OTHER.md": "other/source.md", // missing → should be created
+				},
+			},
+		],
+	};
+
+	const { run } = makeDeps(fs, confirmer, config);
+	const result = await run();
+
+	assert(result.ok);
+	if (result.ok) {
+		assertEquals(result.value.skippedCount, 1);
+		assertEquals(result.value.linkedCount, 1);
+	}
+
+	// First destination should NOT have been removed
+	const removeCalls = fs.calls.filter((c) => c.method === "remove");
+	assertEquals(removeCalls.length, 0);
+});
+
+Deno.test("TC-206: already-correct symlink is counted as linked (idempotent)", async () => {
+	const fs = new FakeFileSystem(
+		new Map<string, FakeFsEntry>([
+			["/ws", { kind: "dir" }],
+			["/ws/projects/repo1", { kind: "dir" }],
+			["/ws/projects/repo1/AGENT.md", { kind: "symlink", target: "../../prompt/BACKEND.md" }],
+			["/ws/prompt/BACKEND.md", { kind: "file" }],
+		]),
+	);
+
+	const confirmer = new FakeConfirmer([]);
+
+	const config: WorkspaceConfig = {
+		workspaces: [
+			{
+				url: "git@example.com:a/r1.git",
+				path: "projects/repo1",
+				branch: "main",
+				isGolang: false,
+				active: true,
+				link: { "AGENT.md": "prompt/BACKEND.md" },
+			},
+		],
+	};
+
+	const { run } = makeDeps(fs, confirmer, config);
+	const result = await run();
+
+	assert(result.ok);
+	if (result.ok) {
+		assertEquals(result.value.linkedCount, 1);
+		assertEquals(result.value.skippedCount, 0);
+	}
+
+	// Zero mutating calls, zero confirm calls
+	const mutatingCalls = fs.calls.filter((c) => ["createSymlink", "remove", "ensureDir"].includes(c.method));
+	assertEquals(mutatingCalls.length, 0);
+	assertEquals(confirmer.messages.length, 0);
+});
+
+Deno.test("TC-207: symlink pointing elsewhere prompts for replacement", async () => {
+	const fs = new FakeFileSystem(
+		new Map<string, FakeFsEntry>([
+			["/ws", { kind: "dir" }],
+			["/ws/projects/repo1", { kind: "dir" }],
+			["/ws/projects/repo1/AGENT.md", { kind: "symlink", target: "../../prompt/WRONG.md" }],
+			["/ws/prompt/BACKEND.md", { kind: "file" }],
+		]),
+	);
+
+	const confirmer = new FakeConfirmer([true]);
+
+	const config: WorkspaceConfig = {
+		workspaces: [
+			{
+				url: "git@example.com:a/r1.git",
+				path: "projects/repo1",
+				branch: "main",
+				isGolang: false,
+				active: true,
+				link: { "AGENT.md": "prompt/BACKEND.md" },
+			},
+		],
+	};
+
+	const { run } = makeDeps(fs, confirmer, config);
+	const result = await run();
+
+	assert(result.ok);
+	if (result.ok) {
+		assertEquals(result.value.linkedCount, 1);
+	}
+
+	// remove + createSymlink called
+	const removeCalls = fs.calls.filter((c) => c.method === "remove");
+	assertEquals(removeCalls.length, 1);
+	const symlinkCalls = fs.calls.filter((c) => c.method === "createSymlink");
+	assertEquals(symlinkCalls.length, 1);
+});
+
+Deno.test("TC-208: missing submodule directory warns and skips", async () => {
+	const fs = new FakeFileSystem(
+		new Map<string, FakeFsEntry>([
+			["/ws", { kind: "dir" }],
+			// projects/repo1 is MISSING (not synced)
+			["/ws/projects/repo2", { kind: "dir" }],
+			["/ws/prompt/BACKEND.md", { kind: "file" }],
+		]),
+	);
+
+	const confirmer = new FakeConfirmer([]);
+
+	const config: WorkspaceConfig = {
+		workspaces: [
+			{
+				url: "git@example.com:a/r1.git",
+				path: "projects/repo1",
+				branch: "main",
+				isGolang: false,
+				active: true,
+				link: { "AGENT.md": "prompt/BACKEND.md" },
+			},
+			{
+				url: "git@example.com:a/r2.git",
+				path: "projects/repo2",
+				branch: "main",
+				isGolang: false,
+				active: true,
+				link: { "AGENT.md": "prompt/BACKEND.md" },
+			},
+		],
+	};
+
+	// Capture console output
+	const logs: string[] = [];
+	const originalLog = console.log;
+	console.log = (...args: string[]) => logs.push(args.join(" "));
+
+	const { run } = makeDeps(fs, confirmer, config);
+	const result = await run();
+
+	console.log = originalLog;
+
+	assert(result.ok);
+	if (result.ok) {
+		assertEquals(result.value.skippedWorkspaceCount, 1);
+		assertEquals(result.value.linkedCount, 1);
+	}
+
+	// Warning mentions sync
+	const warning = logs.find((l) => l.includes("sync"));
+	assert(warning !== undefined);
+});
+
+Deno.test("TC-209: no linkable workspaces returns zeroed report", async () => {
+	const fs = new FakeFileSystem(
+		new Map<string, FakeFsEntry>([
+			["/ws", { kind: "dir" }],
+		]),
+	);
+
+	const confirmer = new FakeConfirmer([]);
+
+	const config: WorkspaceConfig = {
+		workspaces: [
+			{
+				url: "git@example.com:a/r1.git",
+				path: "projects/repo1",
+				branch: "main",
+				isGolang: false,
+				active: true,
+				// no link field
+			},
+		],
+	};
+
+	const { run } = makeDeps(fs, confirmer, config);
+	const result = await run();
+
+	assert(result.ok);
+	if (result.ok) {
+		assertEquals(result.value.linkedCount, 0);
+		assertEquals(result.value.skippedCount, 0);
+		assertEquals(result.value.skippedWorkspaceCount, 0);
+	}
+
+	// No FS calls
+	assertEquals(fs.calls.length, 0);
+});
+
+Deno.test("TC-210: invalid link paths surface as CONFIG_INVALID", async () => {
+	const fs = new FakeFileSystem(
+		new Map<string, FakeFsEntry>([
+			["/ws", { kind: "dir" }],
+			["/ws/projects/repo1", { kind: "dir" }],
+		]),
+	);
+
+	const confirmer = new FakeConfirmer([]);
+
+	const config: WorkspaceConfig = {
+		workspaces: [
+			{
+				url: "git@example.com:a/r1.git",
+				path: "projects/repo1",
+				branch: "main",
+				isGolang: false,
+				active: true,
+				link: { "../evil": "x" },
+			},
+		],
+	};
+
+	const { run } = makeDeps(fs, confirmer, config);
+	const result = await run();
+
+	assertFalse(result.ok);
+	if (!result.ok) {
+		assert(isAppError(result.error));
+		assertEquals(result.error.code, AppErrorCode.CONFIG_INVALID);
+	}
+
+	// No mutating FS calls
+	const mutatingCalls = fs.calls.filter((c) => ["createSymlink", "remove", "ensureDir"].includes(c.method));
+	assertEquals(mutatingCalls.length, 0);
+});

--- a/src/testing/fakes.ts
+++ b/src/testing/fakes.ts
@@ -6,6 +6,7 @@ import type { GitPort } from "../ports/git.ts";
 import type { GoAvailabilityPort, GoWorkPort } from "../ports/go-work.ts";
 import type { HookContext, HookExecutionResult, HookRunner } from "../ports/hook-runner.ts";
 import type { DiscoveryResult, WorkspaceDiscoveryPort } from "../ports/workspace-discovery.ts";
+import type { Confirmer } from "../ports/confirmer.ts";
 import type { PostSyncHook, WorkspaceConfig, WorkspaceConfigItem } from "../types/config.ts";
 
 export type FakeGitState = {
@@ -162,11 +163,38 @@ export class FakeDiscovery implements WorkspaceDiscoveryPort {
 	}
 }
 
+export type FakeFsEntry = {
+	kind: "dir" | "file" | "symlink";
+	target?: string;
+};
+
 export class FakeFileSystem implements FileSystemPort {
 	dirs = new Set<string>();
+	entries = new Map<string, FakeFsEntry>();
+	calls: { method: string; args: unknown[] }[] = [];
+
+	constructor(entries?: Map<string, FakeFsEntry>) {
+		if (entries) {
+			this.entries = entries;
+			// Seed dirs from entries for backward compatibility
+			for (const [p, entry] of entries) {
+				if (entry.kind === "dir") {
+					this.dirs.add(p);
+				}
+			}
+		}
+	}
+
+	private record(method: string, args: unknown[]): void {
+		this.calls.push({ method, args });
+	}
 
 	isDir(path: string): Promise<Result<void, AppError>> {
 		if (this.dirs.has(path)) {
+			return Promise.resolve(Result.ok());
+		}
+		const entry = this.entries.get(path);
+		if (entry && entry.kind === "dir") {
 			return Promise.resolve(Result.ok());
 		}
 		return Promise.resolve(Result.error(new AppError(AppErrorCode.PATH_INVALID, `directory does not exist: ${path}`)));
@@ -174,6 +202,52 @@ export class FakeFileSystem implements FileSystemPort {
 
 	isDirectoryEmpty(_path: string): Promise<Result<boolean, AppError>> {
 		return Promise.resolve(Result.ok(true));
+	}
+
+	lstat(path: string): Promise<Result<{ isDirectory: boolean; isSymlink: boolean }, AppError>> {
+		const entry = this.entries.get(path);
+		if (!entry) {
+			// Fall back to dirs set for backward compatibility
+			if (this.dirs.has(path)) {
+				return Promise.resolve(Result.ok({ isDirectory: true, isSymlink: false }));
+			}
+			return Promise.resolve(Result.error(new AppError(AppErrorCode.FS_FAILED, `lstat failed: ${path}`)));
+		}
+		return Promise.resolve(Result.ok({
+			isDirectory: entry.kind === "dir",
+			isSymlink: entry.kind === "symlink",
+		}));
+	}
+
+	readLink(path: string): Promise<Result<string, AppError>> {
+		const entry = this.entries.get(path);
+		if (!entry || entry.kind !== "symlink") {
+			return Promise.resolve(Result.error(new AppError(AppErrorCode.FS_FAILED, `not a symlink: ${path}`)));
+		}
+		return Promise.resolve(Result.ok(entry.target!));
+	}
+
+	createSymlink(target: string, linkPath: string): Promise<Result<void, AppError>> {
+		this.record("createSymlink", [target, linkPath]);
+		this.entries.set(linkPath, { kind: "symlink", target });
+		return Promise.resolve(Result.ok());
+	}
+
+	remove(path: string): Promise<Result<void, AppError>> {
+		this.record("remove", [path]);
+		if (this.entries.has(path)) {
+			this.entries.delete(path);
+			this.dirs.delete(path);
+			return Promise.resolve(Result.ok());
+		}
+		return Promise.resolve(Result.error(new AppError(AppErrorCode.FS_FAILED, `remove failed: ${path}`)));
+	}
+
+	ensureDir(path: string): Promise<Result<void, AppError>> {
+		this.record("ensureDir", [path]);
+		this.entries.set(path, { kind: "dir" });
+		this.dirs.add(path);
+		return Promise.resolve(Result.ok());
 	}
 }
 
@@ -236,5 +310,23 @@ export class FakeGoWork implements GoWorkPort, GoAvailabilityPort {
 	isAvailable(): Promise<Result<boolean, AppError>> {
 		this.record("isAvailable", []);
 		return Promise.resolve(Result.ok(this.available));
+	}
+}
+
+export class FakeConfirmer implements Confirmer {
+	answers: boolean[];
+	messages: string[] = [];
+
+	constructor(answers: boolean[]) {
+		this.answers = [...answers];
+	}
+
+	confirm(message: string): Promise<Result<boolean, AppError>> {
+		this.messages.push(message);
+		const answer = this.answers.shift();
+		if (answer === undefined) {
+			return Promise.resolve(Result.error(new AppError(AppErrorCode.CANCELLED, "no more canned answers")));
+		}
+		return Promise.resolve(Result.ok(answer));
 	}
 }


### PR DESCRIPTION
## Summary

Adds a new `link` command that creates **relative symlinks** inside configured submodules, pointing at files or directories in the workspace root. Driven by a new optional per-workspace `link` map in `workspace.yml`:

```yaml
workspaces:
  - url: git@example.com:org/repo.git
    path: projects/repo
    branch: main
    isGolang: true
    active: true
    link:
      .agents: .agents            # dir link:  <submodule>/.agents  -> ../../.agents
      AGENT.md: prompt/BACKEND.md # file link: <submodule>/AGENT.md -> ../../prompt/BACKEND.md
```

## Behavior

- **Two-phase execution** — all-or-nothing validation runs across every workspace before any filesystem change; missing sources or real-directory conflicts abort the run with a non-zero exit and zero mutations
- **Interactive overwrites** — existing files or incorrect/dangling symlinks prompt `y/N` (default `N` skips and continues; user-skips still exit 0)
- **Portable** — symlink targets are relative, so the whole workspace folder can be moved without breaking links
- **Idempotent** — already-correct links are silently re-counted, so repeated runs report identical numbers with no prompts and no mutations
- **Forgiving** — missing submodule directories emit a warning (suggesting `sync`) and are skipped; `active: false` workspaces are ignored
- **Safe paths** — absolute paths, `..` traversal, and empty keys/values are rejected as `CONFIG_INVALID`

## Implementation

Follows the existing ports/adapters + layered architecture (AGENTS.md):

- `domain/link-plan.ts` — pure path validation + relative target computation (no I/O)
- `services/link.ts` — `LinkService` two-phase orchestration, `Result`/`AppError` throughout
- `ports/confirmer.ts` + `adapters/confirmer.ts` — prompt abstraction keeps the service TTY-agnostic for future sync-pipeline integration
- `ports/file-system.ts` — extended additively (`lstat`, `readLink`, `createSymlink`, `remove`, `ensureDir`); new `FS_FAILED` and `LINK_VALIDATION_FAILED` error codes
- Thin `cmds/link.ts` owns all summary presentation; everything wired in the composition root

## Testing

- `deno task check` green: **76 tests, 0 failures** (fmt + lint clean)
- 15 planned test cases (TC-101..TC-301) covering path security, workspace filtering, relative-path matrix, all-or-nothing validation, `y/N` branches, idempotency, and missing submodules
- Verified on a real filesystem: create → `readlink` targets correct → repeated runs identical (`✅ linked: 2, ⏭️  skipped: 0`)

## Documentation

- README: Link Command section with config example and behavior notes
- `example/workspace.yml`: `link` map added to `modules/repo2`
- PRD in `docs/prds/`; plan/review trail in `.context/`

## Follow-ups (future PRs)

- `--yes` / non-interactive mode
- Integration into the `sync` pipeline
