### PR TITLE
fix(sync): re-attach detached submodules when HEAD is behind branch tip

### DIFF
--- a/src/adapters/git.ts
+++ b/src/adapters/git.ts
@@ -224,6 +224,51 @@ export class GitManager implements GitPort {
 		}).mapError((error) => new AppError(AppErrorCode.GIT_FAILED, `Failed to check detached HEAD state`, { cause: error }));
 	}
 
+	async isHeadBehindBranch(branch: string): Promise<Result<boolean, AppError>> {
+		return await Result.fromAsyncCatching(async () => {
+			// Compare against local branch and origin/<branch> — heal is safe if HEAD
+			// is contained in either ref's history.
+			const candidates: string[] = [];
+			if (await this.refExists(`refs/heads/${branch}`)) {
+				candidates.push(branch);
+			}
+			if (await this.refExists(`refs/remotes/origin/${branch}`)) {
+				candidates.push(`origin/${branch}`);
+			}
+
+			for (const target of candidates) {
+				// exit 0 -> HEAD is ancestor of (or equal to) target
+				// exit 1 -> not an ancestor (diverged)
+				// other   -> genuine failure
+				const proc = await new Deno.Command("git", {
+					args: ["merge-base", "--is-ancestor", "HEAD", target],
+					cwd: this.cwd,
+					stdout: "null",
+					stderr: "null",
+				}).output();
+
+				if (proc.success) {
+					return true;
+				}
+				if (proc.code !== 1) {
+					throw new Error(`Git command failed with exit code ${proc.code}: git merge-base --is-ancestor HEAD ${target}`);
+				}
+			}
+
+			return false;
+		}).mapError((error) => new AppError(AppErrorCode.GIT_FAILED, `Failed to check HEAD ancestry against branch ${branch}`, { cause: error }));
+	}
+
+	private async refExists(ref: string): Promise<boolean> {
+		const proc = await new Deno.Command("git", {
+			args: ["rev-parse", "--verify", "--quiet", ref],
+			cwd: this.cwd,
+			stdout: "null",
+			stderr: "null",
+		}).output();
+		return proc.success;
+	}
+
 	async getHeadSha(): Promise<Result<string, AppError>> {
 		return await Result.fromAsyncCatching(async () => {
 			const result = await this.runCommand(["rev-parse", "HEAD"]);

--- a/src/composition_test.ts
+++ b/src/composition_test.ts
@@ -54,6 +54,8 @@ Deno.test("gitFactory returns an object assignable to GitPort", () => {
 	assert(typeof git.getCurrentBranch === "function");
 	assert(typeof git.pullOriginBranch === "function");
 	assert(typeof git.isRepository === "function");
+	assert(typeof git.isDetachedHead === "function");
+	assert(typeof git.isHeadBehindBranch === "function");
 	assert(typeof git.isWorkingDirectoryClean === "function");
 	assert(typeof git.getPorcelainStatus === "function");
 	assert(typeof git.stash === "function");

--- a/src/integration/submodule_readiness_test.ts
+++ b/src/integration/submodule_readiness_test.ts
@@ -204,15 +204,15 @@ Deno.test(
 );
 
 // -----------------------------------------------------------------------------
-// TC-5: sync warn-and-skips detached-behind-tip submodule
+// TC-5: sync re-attaches detached-behind-tip submodule (fast-forward heal)
 // -----------------------------------------------------------------------------
 
 Deno.test(
-	"submodule readiness — sync warn-and-skips detached-behind-tip submodule (P1)",
+	"submodule readiness — sync re-attaches detached-behind-tip submodule (P0)",
 	async () => {
 		const fixture = await buildWorktreeFixture({ branch: "feature" });
 		try {
-			// Put submodule in detached state behind the tip
+			// Put submodule in detached state behind the tip (recorded gitlink SHA)
 			const checkoutResult = await new Deno.Command("git", {
 				args: ["checkout", "HEAD~1"],
 				cwd: fixture.submodulePath,
@@ -221,37 +221,93 @@ Deno.test(
 			}).output();
 			assertEquals(checkoutResult.success, true, "pre-condition: should checkout HEAD~1");
 
-			// Verify it's detached and not at tip
 			const subGit = new GitManager(fixture.submodulePath);
+
 			const isDetached = await subGit.isDetachedHead();
 			assert(isDetached.ok);
 			assertEquals(isDetached.value, true, "pre-condition: submodule should be detached");
 
 			const branch = await subGit.getCurrentBranch();
 			assert(branch.ok);
-			// getCurrentBranch resolver returns the branch name only if at tip
-			// Since we're behind tip, it should return "HEAD" (or not match "feature")
 			assertNotEquals(branch.value, "feature", "pre-condition: should not be at feature tip");
 
 			const { syncService } = wireServicesForFixture(fixture);
-			const syncInput: SyncInput = {
-				debug: false,
-				concurrency: 1,
-			};
-			const r = await syncService.run(syncInput);
+			const r = await syncService.run({ debug: false, concurrency: 1 });
 
-			// Skip is NOT a failure
+			assert(r.ok, `syncService failed: ${!r.ok ? r.error.message : ""}`);
+			assertEquals(r.value.skippedDetachedCount, 0, "should not skip a healable behind-tip HEAD");
+
+			// HEAD should now be re-attached to the configured branch
+			const isDetachedAfter = await subGit.isDetachedHead();
+			assert(isDetachedAfter.ok);
+			assertEquals(isDetachedAfter.value, false, "submodule should be re-attached to branch");
+
+			const branchAfter = await subGit.getCurrentBranch();
+			assert(branchAfter.ok);
+			assertEquals(branchAfter.value, "feature", "submodule should be on feature branch");
+		} finally {
+			await fixture.cleanup();
+		}
+	},
+);
+
+// -----------------------------------------------------------------------------
+// TC-5b: sync warn-and-skips detached diverged submodule
+// -----------------------------------------------------------------------------
+
+Deno.test(
+	"submodule readiness — sync warn-and-skips detached-diverged submodule (P1)",
+	async () => {
+		const fixture = await buildWorktreeFixture({ branch: "feature" });
+		try {
+			// Detach behind the tip, then create a dangling commit so HEAD is not
+			// reachable from the configured branch — this is the real case where
+			// re-attaching would silently abandon work.
+			const checkoutResult = await new Deno.Command("git", {
+				args: ["checkout", "HEAD~1"],
+				cwd: fixture.submodulePath,
+				stdout: "null",
+				stderr: "null",
+			}).output();
+			assertEquals(checkoutResult.success, true, "pre-condition: should checkout HEAD~1");
+
+			await new Deno.Command("git", {
+				args: ["config", "user.email", "test@test.test"],
+				cwd: fixture.submodulePath,
+				stdout: "null",
+				stderr: "null",
+			}).output();
+			await new Deno.Command("git", {
+				args: ["config", "user.name", "Test User"],
+				cwd: fixture.submodulePath,
+				stdout: "null",
+				stderr: "null",
+			}).output();
+			const danglingCommit = await new Deno.Command("git", {
+				args: ["commit", "--allow-empty", "-m", "dangling"],
+				cwd: fixture.submodulePath,
+				stdout: "null",
+				stderr: "null",
+			}).output();
+			assertEquals(danglingCommit.success, true, "pre-condition: should create dangling commit");
+
+			const subGit = new GitManager(fixture.submodulePath);
+			const headShaBefore = await subGit.getHeadSha();
+			assert(headShaBefore.ok);
+
+			const { syncService } = wireServicesForFixture(fixture);
+			const r = await syncService.run({ debug: false, concurrency: 1 });
+
 			assert(r.ok, `syncService failed: ${!r.ok ? r.error.message : ""}`);
 			assertEquals(r.value.skippedDetachedCount, 1, "should count skipped detached");
 
-			// Verify HEAD was NOT mutated
 			const headShaAfter = await subGit.getHeadSha();
 			assert(headShaAfter.ok);
-			// The sha should still be HEAD~1, not the tip
-			// We can verify by checking it's still detached
+			assertEquals(headShaAfter.value, headShaBefore.value, "diverged HEAD must not be mutated");
+
 			const isDetachedAfter = await subGit.isDetachedHead();
 			assert(isDetachedAfter.ok);
-			assertEquals(isDetachedAfter.value, true, "submodule should remain detached (not mutated)");
+			assertEquals(isDetachedAfter.value, true, "submodule should remain detached");
 		} finally {
 			await fixture.cleanup();
 		}
@@ -365,7 +421,7 @@ function makeDeps({
 	existingDirs,
 }: {
 	config: WorkspaceConfig;
-	gitStates?: Record<string, { currentBranch?: string; isClean?: boolean; isRepo?: boolean; isDetached?: boolean; headSha?: string }>;
+	gitStates?: Record<string, { currentBranch?: string; isClean?: boolean; isRepo?: boolean; isDetached?: boolean; isHeadBehindBranch?: boolean; headSha?: string }>;
 	existingDirs?: string[];
 } = { config: { workspaces: [] } }) {
 	const discovery = makeDiscovery();
@@ -385,6 +441,7 @@ function makeDeps({
 				isClean: state.isClean ?? true,
 				isRepo: state.isRepo ?? true,
 				isDetached: state.isDetached ?? false,
+				isHeadBehindBranch: state.isHeadBehindBranch ?? false,
 				headSha: state.headSha,
 			});
 			gitInstances.set(cwd, git);

--- a/src/ports/git.ts
+++ b/src/ports/git.ts
@@ -18,6 +18,14 @@ export type GitPort = {
 	 */
 	isDetachedHead(): Promise<Result<boolean, AppError>>;
 	/**
+	 * Returns true if HEAD is contained in the given branch's history — i.e. HEAD is
+	 * an ancestor of (or equal to) the branch tip — so re-attaching a detached HEAD
+	 * via checkout + pull abandons no commits.
+	 * Compares against the local branch and `origin/<branch>` (whichever refs exist).
+	 * Returns false when HEAD has commits not on the branch, or no such ref exists.
+	 */
+	isHeadBehindBranch(branch: string): Promise<Result<boolean, AppError>>;
+	/**
 	 * Returns the full lowercase SHA of HEAD.
 	 */
 	getHeadSha(): Promise<Result<string, AppError>>;

--- a/src/services/sync.ts
+++ b/src/services/sync.ts
@@ -234,14 +234,17 @@ export class SyncService {
 		}
 
 		if (isDetached.value) {
-			const currentBranch = await subGit.getCurrentBranch();
-			if (!currentBranch.ok) {
-				console.log(red(`❌ Failed to get current branch: ${workspace.path}: ${currentBranch.error.message}`));
-				return Result.error(currentBranch.error);
+			// Heal detached HEAD when HEAD is at or behind the configured branch tip.
+			// In worktree/submodule setups, git pins HEAD at the recorded gitlink SHA,
+			// which is an ancestor of the branch tip; re-attaching is a pure fast-forward.
+			// Only skip when HEAD has commits not on the branch (true divergence).
+			const behind = await subGit.isHeadBehindBranch(workspace.branch);
+			if (!behind.ok) {
+				console.log(red(`❌ Failed to check branch ancestry: ${workspace.path}: ${behind.error.message}`));
+				return Result.error(behind.error);
 			}
 
-			// Detached at tip: resolver returns the branch name → re-attach
-			if (currentBranch.value === workspace.branch) {
+			if (behind.value) {
 				console.log(yellow(`🔗 Re-attaching ${workspace.path} to ${workspace.branch}`));
 				const checkout = await subGit.checkoutBranch(workspace.branch);
 				if (!checkout.ok) {
@@ -250,13 +253,13 @@ export class SyncService {
 				}
 				// Continue into dirty-check + pull via fall-through
 			} else {
-				// Detached NOT at tip (resolver returned "HEAD" or wrong branch)
+				// Detached with commits not on the configured branch
 				// WARN-AND-SKIP: never silently abandon commits
 				const headSha = await subGit.getHeadSha();
 				const shortSha = headSha.ok ? headSha.value.slice(0, 7) : "unknown";
 
 				console.log(yellow(
-					`⚠️  ${workspace.path} is detached @${shortSha}, not on any branch tip — skipping. Run 'git -C ${workspacePath} status' to inspect.`,
+					`⚠️  ${workspace.path} is detached @${shortSha} with commits not on ${workspace.branch} — skipping. Run 'git -C ${workspacePath} status' to inspect.`,
 				));
 
 				// Skip is NOT a failure; increment skippedDetachedCount

--- a/src/services/sync_test.ts
+++ b/src/services/sync_test.ts
@@ -25,7 +25,7 @@ function makeDeps({
 	goAvailable,
 }: {
 	config: WorkspaceConfig;
-	gitStates?: Record<string, { currentBranch?: string; isClean?: boolean }>;
+	gitStates?: Record<string, { currentBranch?: string; isClean?: boolean; isDetached?: boolean; isHeadBehindBranch?: boolean }>;
 	existingDirs?: string[];
 	goAvailable?: boolean;
 } = { config: { workspaces: [] } }) {
@@ -44,6 +44,8 @@ function makeDeps({
 			git = new FakeGit({
 				currentBranch: state.currentBranch ?? "main",
 				isClean: state.isClean ?? true,
+				isDetached: state.isDetached ?? false,
+				isHeadBehindBranch: state.isHeadBehindBranch ?? false,
 			});
 			gitInstances.set(cwd, git);
 		}
@@ -156,6 +158,62 @@ Deno.test("SyncService: branch mismatch → checkoutBranch then pull", async () 
 	const checkoutCalls = git.calls.filter((c) => c.method === "checkoutBranch");
 	assertEquals(checkoutCalls.length, 1);
 	assertEquals(checkoutCalls[0].args[0], "feature");
+});
+
+Deno.test("SyncService: detached HEAD behind branch tip → re-attach and pull", async () => {
+	const config: WorkspaceConfig = {
+		workspaces: [
+			{ url: "git@github.com:user/repo.git", path: "repo", branch: "develop", isGolang: false, active: true },
+		],
+	};
+	const repoPath = join(workspaceRoot, "repo");
+	const { service, getGit } = makeDeps({
+		config,
+		existingDirs: [repoPath],
+		gitStates: { [repoPath]: { currentBranch: "HEAD", isDetached: true, isHeadBehindBranch: true } },
+	});
+
+	const result = await service.run({});
+
+	assert(result.ok, `expected ok, got: ${JSON.stringify(result.error)}`);
+	const git = getGit(repoPath);
+	if (!git) throw new Error("Expected git instance for repoPath");
+	const checkoutCalls = git.calls.filter((c) => c.method === "checkoutBranch");
+	const pullCalls = git.calls.filter((c) => c.method === "pullOriginBranch");
+	const isHeadBehindCalls = git.calls.filter((c) => c.method === "isHeadBehindBranch");
+
+	assertEquals(isHeadBehindCalls.length, 1);
+	assertEquals(checkoutCalls.length, 1);
+	assertEquals(checkoutCalls[0].args[0], "develop");
+	assertEquals(pullCalls.length, 1);
+	assertEquals(pullCalls[0].args[0], "develop");
+});
+
+Deno.test("SyncService: detached HEAD with commits not on branch → warn-and-skip", async () => {
+	const config: WorkspaceConfig = {
+		workspaces: [
+			{ url: "git@github.com:user/repo.git", path: "repo", branch: "develop", isGolang: false, active: true },
+		],
+	};
+	const repoPath = join(workspaceRoot, "repo");
+	const { service, getGit } = makeDeps({
+		config,
+		existingDirs: [repoPath],
+		gitStates: { [repoPath]: { currentBranch: "HEAD", isDetached: true, isHeadBehindBranch: false } },
+	});
+
+	const result = await service.run({});
+
+	assert(result.ok, `expected ok, got: ${JSON.stringify(result.error)}`);
+	assertEquals(result.value.syncedCount, 1);
+	assertEquals(result.value.skippedDetachedCount, 1);
+
+	const git = getGit(repoPath);
+	if (!git) throw new Error("Expected git instance for repoPath");
+	const checkoutCalls = git.calls.filter((c) => c.method === "checkoutBranch");
+	const pullCalls = git.calls.filter((c) => c.method === "pullOriginBranch");
+	assertEquals(checkoutCalls.length, 0, "should not checkout a diverged detached HEAD");
+	assertEquals(pullCalls.length, 0, "should not pull a skipped workspace");
 });
 
 Deno.test("SyncService: dirty workspace → stash, pull, stashPop", async () => {

--- a/src/testing/fakes.ts
+++ b/src/testing/fakes.ts
@@ -16,6 +16,7 @@ export type FakeGitState = {
 	modifiedFiles?: number;
 	untrackedFiles?: number;
 	isDetached?: boolean;
+	isHeadBehindBranch?: boolean;
 	headSha?: string;
 	failNext?: string;
 };
@@ -51,7 +52,12 @@ export class FakeGit implements GitPort {
 
 	checkoutBranch(branch: string): Promise<Result<void, AppError>> {
 		this.record("checkoutBranch", [branch]);
-		return Promise.resolve(this.nextResult());
+		const result = this.nextResult();
+		if (result.ok) {
+			this.state.currentBranch = branch;
+			this.state.isDetached = false;
+		}
+		return Promise.resolve(result);
 	}
 
 	getCurrentBranch(): Promise<Result<string, AppError>> {
@@ -66,6 +72,11 @@ export class FakeGit implements GitPort {
 	isDetachedHead(): Promise<Result<boolean, AppError>> {
 		this.record("isDetachedHead", []);
 		return Promise.resolve(Result.ok(this.state.isDetached ?? false));
+	}
+
+	isHeadBehindBranch(branch: string): Promise<Result<boolean, AppError>> {
+		this.record("isHeadBehindBranch", [branch]);
+		return Promise.resolve(Result.ok(this.state.isHeadBehindBranch ?? false));
 	}
 
 	getHeadSha(): Promise<Result<string, AppError>> {


### PR DESCRIPTION
## Problem

When using `workspace-manager sync` inside a git worktree, submodules are initialized at the superproject's recorded gitlink SHA. This leaves them in detached HEAD state at a commit that is usually *behind* the configured branch tip.

The previous sync logic only re-attached a detached HEAD when it was exactly at a local branch tip. As a result, every sync run warned and skipped these worktree submodules forever, even though re-attaching would be a safe fast-forward.

## Solution

Extend the detached-HEAD healing path in `SyncService` to also re-attach when HEAD is an ancestor of (or equal to) the configured branch tip. The safety invariant — "never silently abandon commits" — is preserved: sync still skips only when HEAD contains commits that are not reachable from the configured branch.

## Changes

- Added `GitPort.isHeadBehindBranch(branch)` to check whether HEAD is contained in the local branch or `origin/<branch>` history.
- Implemented `GitManager.isHeadBehindBranch` using `git merge-base --is-ancestor HEAD <ref>`.
- Updated `SyncService.syncSingleWorkspace` to heal detached-behind-tip submodules by checking out the branch and pulling.
- Updated `FakeGit` to support the new port method and to update branch/detached state on `checkoutBranch`.
- Updated and added tests:
  - TC-5 now asserts that a detached-behind-tip submodule is re-attached.
  - New TC-5b asserts that a detached-diverged submodule is still skipped.
  - Added unit tests for behind-tip healing and diverged skipping.

## Testing

- `deno fmt --check` and `deno lint` pass.
- `deno test -A src/` passes (107 tests).
- Verified live on the existing `test-wm-worktree` worktree and on a freshly created worktree (`test-wm-worktree-fix`): all active submodules initialized, re-attached, and pulled with zero skipped-detached warnings.
