### PR TITLE
perf(sync): parallelize sync pipeline and reduce per-repo overhead

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,34 @@ A command-line tool for managing workspaces with Git submodules and Go workspace
 - **Status monitoring** with branch tracking and dirty state detection
 - YAML-based configuration
 - Debug mode support
+- **SSH connection reuse** via OpenSSH ControlMaster for faster sync/update against SSH remotes
+
+## SSH Connection Multiplexing
+
+Sync and update operations against SSH remotes (`git@github.com:...`) automatically reuse the underlying SSH connection. On the first network operation the CLI opens a shared socket in `/tmp/wm-ssh-<user>/` (a short path is required by the macOS Unix socket length limit); subsequent operations within a 60-second window skip the TCP + auth handshake. The socket directory is created with `0700` permissions and must be owned by the current user, otherwise multiplexing is disabled automatically.
+
+No configuration is required. HTTPS remotes are unaffected.
+
+### Opt-out
+
+To use your own SSH options, set `GIT_SSH_COMMAND` in your environment:
+
+```bash
+export GIT_SSH_COMMAND="ssh -i ~/.ssh/my_key"
+```
+
+When `GIT_SSH_COMMAND` is set the CLI preserves it verbatim and does not inject any ControlMaster options.
+
+### Equivalent `~/.ssh/config` snippet
+
+If you prefer persistent connection reuse outside this tool, add the following to `~/.ssh/config`:
+
+```
+Host github.com
+  ControlMaster auto
+  ControlPath /tmp/wm-ssh-<user>/%C
+  ControlPersist 60
+```
 
 ## Installation
 
@@ -77,6 +105,18 @@ workspace-manager sync [options]
 - `-d, --debug` - Enable debug mode
 - `-j, --concurrency <number>` - Number of concurrent operations (default: 4)
 - `-y, --yes` - Accept all changes (⚠️ not yet implemented)
+
+**Sync behavior:**
+
+- `sync` fetches `origin/<branch>` and fast-forwards the local branch only when
+  it is behind the remote tip. Already up-to-date repos skip the merge entirely
+  (no index write / lock churn) and are reported as "Up-to-date".
+- On first sync, uninitialized submodules registered in `.gitmodules` are cloned
+  in parallel via `git submodule update --init --jobs=<concurrency>`.
+- Diverged histories are **never** silently merged. If your local branch and
+  `origin/<branch>` have diverged, the workspace fails with a `GIT_FAILED` error
+  and instructions to resolve manually (e.g. `git pull --rebase` or a manual
+  merge) for that path.
 
 ### Update Command
 

--- a/deno.json
+++ b/deno.json
@@ -8,7 +8,7 @@
     "fmt": "deno fmt",
     "fmt:check": "deno fmt --check",
     "lint": "deno lint",
-    "local-install": "deno install -fr --global --allow-run --allow-write --allow-read --allow-env --allow-net --config deno.json --name workspace-manager-local ./main.ts"
+    "local-install": "deno install -fr --global --allow-run --allow-write --allow-read --allow-env --allow-net --no-prompt --config deno.json --name workspace-manager-local ./main.ts"
   },
   "imports": {
     "@117/mutex": "jsr:@117/mutex@^1.0.8",

--- a/src/adapters/git.ts
+++ b/src/adapters/git.ts
@@ -1,16 +1,80 @@
 import { createMutex, type Mutex } from "@117/mutex";
+import { yellow } from "@std/fmt/colors";
 import { Result } from "typescript-result";
 import { AppError, AppErrorCode } from "../libs/app-error.ts";
 import { wrapErrorResult } from "../libs/errors.ts";
-import type { GitPort } from "../ports/git.ts";
+import { buildGitEnv, getSshSocketDir } from "../libs/git-env.ts";
+import type { BranchState, GitPort, SyncBranchResult } from "../ports/git.ts";
 
 // Registry to share mutexes by cwd
 const mutexRegistry = new Map<string, Mutex>();
 
+// One-per-process SSH multiplex socket directory state.
+let socketDirEnsured = false;
+let ensuredSocketDir: string | null = null;
+
+/**
+ * Ensure the SSH multiplex socket directory exists.
+ *
+ * Returns the directory path on success, or `null` when no usable socket
+ * directory is available or it cannot be created. In the failure case the
+ * caller should fall back to spawning git without connection reuse.
+ *
+ * Because the preferred location lives under the world-writable `/tmp`, the
+ * directory must be owned by the current user and private (0700); otherwise
+ * mux is disabled rather than trusting a foreign directory.
+ *
+ * `env` is injectable for tests; production callers use the process env.
+ */
+export async function ensureSshSocketDir(
+	debug?: boolean,
+	env: Record<string, string | undefined> = Deno.env.toObject(),
+): Promise<string | null> {
+	if (socketDirEnsured) {
+		return ensuredSocketDir;
+	}
+	socketDirEnsured = true;
+
+	const dir = getSshSocketDir(env);
+	if (!dir) {
+		return null;
+	}
+
+	const result = await Result.fromAsyncCatching(async () => {
+		await Deno.mkdir(dir, { recursive: true, mode: 0o700 });
+		if (Deno.build.os !== "windows") {
+			const stat = await Deno.stat(dir);
+			if (stat.uid !== Deno.uid()) {
+				throw new Error(`socket dir ${dir} is owned by uid ${stat.uid}, expected ${Deno.uid()}`);
+			}
+			// Enforce privacy even when the dir pre-existed with laxer perms.
+			await Deno.chmod(dir, 0o700);
+		}
+	});
+	if (!result.ok) {
+		if (debug) {
+			console.warn(yellow(`⚠️  Failed to create SSH socket directory ${dir}; connection multiplexing disabled: ${result.error.message}`));
+		}
+		return null;
+	}
+
+	ensuredSocketDir = dir;
+	return dir;
+}
+
+/** Test-only hook to reset the module-level socket-dir ensure state. */
+export function resetSocketDirStateForTests(): void {
+	socketDirEnsured = false;
+	ensuredSocketDir = null;
+}
+
 export class GitManager implements GitPort {
 	private readonly mutex: Mutex;
 
-	constructor(private readonly cwd: string) {
+	constructor(
+		private readonly cwd: string,
+		private readonly debug?: boolean,
+	) {
 		// Share mutex for same cwd across instances
 		if (!mutexRegistry.has(cwd)) {
 			mutexRegistry.set(cwd, createMutex());
@@ -154,6 +218,55 @@ export class GitManager implements GitPort {
 		);
 	}
 
+	async syncBranch(branch: string): Promise<Result<SyncBranchResult, AppError>> {
+		const fetchResult = await this.runCommandWithErrorContext(
+			["fetch", "origin", branch],
+			`Failed to fetch origin/${branch}`,
+		);
+		if (!fetchResult.ok) {
+			return Result.error(fetchResult.error);
+		}
+
+		const headResult = await this.getHeadSha();
+		if (!headResult.ok) {
+			return Result.error(headResult.error);
+		}
+
+		const remoteResult = await this.getRefSha(`refs/remotes/origin/${branch}`);
+		if (!remoteResult.ok) {
+			return Result.error(remoteResult.error);
+		}
+
+		if (headResult.value === remoteResult.value) {
+			return Result.ok({ updated: false });
+		}
+
+		const mergeResult = await this.runCommand(["merge", "--ff-only", `origin/${branch}`]);
+		if (!mergeResult.ok) {
+			return Result.error(
+				new AppError(
+					AppErrorCode.GIT_FAILED,
+					`Cannot fast-forward ${this.cwd} to origin/${branch}: branches have diverged. Resolve manually (e.g. git -C ${this.cwd} pull --rebase or git -C ${this.cwd} merge).`,
+					{ cause: mergeResult.error, context: { cwd: this.cwd, branch } },
+				),
+			);
+		}
+
+		return Result.ok({ updated: true });
+	}
+
+	private async getRefSha(ref: string): Promise<Result<string, AppError>> {
+		return await Result.fromAsyncCatching(async () => {
+			const result = await this.runCommand(["rev-parse", ref]);
+			if (!result.ok) {
+				throw result.error;
+			}
+			return new TextDecoder().decode(result.value.stdout).trim().toLowerCase();
+		}).mapError(
+			(error) => new AppError(AppErrorCode.GIT_FAILED, `Failed to resolve ${ref}`, { cause: error }),
+		);
+	}
+
 	// Repository operations
 	async fetch(): Promise<Result<void, AppError>> {
 		return await this.runCommandWithErrorContext(
@@ -164,15 +277,10 @@ export class GitManager implements GitPort {
 
 	async isRepository(): Promise<Result<boolean, AppError>> {
 		return await Result.fromAsyncCatching(async () => {
-			// Cheap first check: is there a git repo accessible from here?
-			const gitDirResult = await this.runCommand(["rev-parse", "--git-dir"]);
-			if (!gitDirResult.ok || !gitDirResult.value.success) {
-				return false;
-			}
-
-			// Harden: toplevel must equal this.cwd
-			// This prevents false positives for uninitialized submodule dirs
-			// inside a superproject (git walks up to parent repo otherwise).
+			// `rev-parse --show-toplevel` fails outside a work tree, so a single
+			// invocation is sufficient. Harden: toplevel must equal this.cwd to
+			// prevent false positives for uninitialized submodule dirs inside a
+			// superproject (git would otherwise walk up to the parent repo).
 			const toplevelResult = await this.runCommand(["rev-parse", "--show-toplevel"]);
 			if (!toplevelResult.ok || !toplevelResult.value.success) {
 				return false;
@@ -210,18 +318,34 @@ export class GitManager implements GitPort {
 		// - exit 0 + stdout = branch name -> not detached
 		// - exit non-zero -> detached
 		return await Result.fromAsyncCatching(async () => {
-			// Use async output() to satisfy require-await lint rule
-			const proc = await new Deno.Command("git", {
-				args: ["symbolic-ref", "--quiet", "--short", "HEAD"],
-				cwd: this.cwd,
+			const proc = await this.spawnGit(["symbolic-ref", "--quiet", "--short", "HEAD"], {
 				stdout: "null",
 				stderr: "null",
-			}).output();
+			});
 
 			// exit 0 -> not detached
 			// exit non-zero -> detached
 			return !proc.success;
 		}).mapError((error) => new AppError(AppErrorCode.GIT_FAILED, `Failed to check detached HEAD state`, { cause: error }));
+	}
+
+	async getBranchState(): Promise<Result<BranchState, AppError>> {
+		// One spawn: git symbolic-ref --short HEAD
+		// - exit 0 + stdout = branch name -> { detached: false, branch }
+		// - exit non-zero -> { detached: true, branch: null }
+		return await Result.fromAsyncCatching(async () => {
+			const proc = await this.spawnGit(["symbolic-ref", "--short", "HEAD"], {
+				stdout: "piped",
+				stderr: "null",
+			});
+
+			if (proc.success) {
+				const branch = new TextDecoder().decode(proc.stdout).trim();
+				return { detached: false, branch };
+			}
+
+			return { detached: true, branch: null };
+		}).mapError((error) => new AppError(AppErrorCode.GIT_FAILED, `Failed to get branch state`, { cause: error }));
 	}
 
 	async isHeadBehindBranch(branch: string): Promise<Result<boolean, AppError>> {
@@ -240,12 +364,10 @@ export class GitManager implements GitPort {
 				// exit 0 -> HEAD is ancestor of (or equal to) target
 				// exit 1 -> not an ancestor (diverged)
 				// other   -> genuine failure
-				const proc = await new Deno.Command("git", {
-					args: ["merge-base", "--is-ancestor", "HEAD", target],
-					cwd: this.cwd,
+				const proc = await this.spawnGit(["merge-base", "--is-ancestor", "HEAD", target], {
 					stdout: "null",
 					stderr: "null",
-				}).output();
+				});
 
 				if (proc.success) {
 					return true;
@@ -260,12 +382,10 @@ export class GitManager implements GitPort {
 	}
 
 	private async refExists(ref: string): Promise<boolean> {
-		const proc = await new Deno.Command("git", {
-			args: ["rev-parse", "--verify", "--quiet", ref],
-			cwd: this.cwd,
+		const proc = await this.spawnGit(["rev-parse", "--verify", "--quiet", ref], {
 			stdout: "null",
 			stderr: "null",
-		}).output();
+		});
 		return proc.success;
 	}
 
@@ -284,6 +404,20 @@ export class GitManager implements GitPort {
 		const result = await this.runCommandWithErrorContext(
 			["submodule", "update", "--init", path],
 			`Failed to initialize submodule at ${path}`,
+		);
+		this.mutex.release();
+		return result;
+	}
+
+	async submoduleInitMany(paths: string[], jobs: number): Promise<Result<void, AppError>> {
+		if (paths.length === 0) {
+			return Result.ok(undefined);
+		}
+
+		await this.mutex.acquire();
+		const result = await this.runCommandWithErrorContext(
+			["submodule", "update", "--init", `--jobs=${jobs}`, "--", ...paths],
+			`Failed to batch initialize submodules`,
 		);
 		this.mutex.release();
 		return result;
@@ -349,18 +483,29 @@ export class GitManager implements GitPort {
 	}
 
 	// Private utility methods
+	private async spawnGit(
+		args: string[],
+		options: { stdout?: "null" | "piped"; stderr?: "null" | "piped" } = {},
+	): Promise<Deno.CommandOutput> {
+		const socketDir = await ensureSshSocketDir(this.debug);
+		const env = buildGitEnv(Deno.env.toObject(), socketDir);
+		return await new Deno.Command("git", {
+			args,
+			cwd: this.cwd,
+			env,
+			stdout: options.stdout ?? "piped",
+			stderr: options.stderr ?? "null",
+		}).output();
+	}
+
 	private async runCommand(
 		args: string[],
 	): Promise<Result<Deno.CommandOutput, AppError>> {
 		return await Result.fromAsyncCatching(async () => {
-			const output = await new Deno.Command("git", {
-				args,
-				cwd: this.cwd,
-				// TODO: Capture stderr for better error reporting instead of suppressing it
-				stderr: "null",
-			}).output();
+			const output = await this.spawnGit(args, { stderr: "piped" });
 			if (!output.success) {
-				throw new Error(`Git command failed with exit code ${output.code}: git ${args.join(" ")}`);
+				const stderr = new TextDecoder().decode(output.stderr).trim();
+				throw new Error(`Git command failed with exit code ${output.code}: git ${args.join(" ")}${stderr ? `\n${stderr}` : ""}`);
 			}
 			return output;
 		}).mapError((error) => new AppError(AppErrorCode.GIT_FAILED, `Git command failed: git ${args.join(" ")}`, { cause: error }));

--- a/src/adapters/git_test.ts
+++ b/src/adapters/git_test.ts
@@ -1,0 +1,64 @@
+import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import { ensureSshSocketDir, GitManager, resetSocketDirStateForTests } from "./git.ts";
+
+Deno.test("ensureSshSocketDir creates socket dir with 0700 on first call", async () => {
+	resetSocketDirStateForTests();
+	// Keep the temp HOME short: getSshSocketDir rejects overlong paths by design.
+	const tempHome = await Deno.makeTempDir({ dir: "/tmp", prefix: "wmt" });
+	try {
+		// No USER/LOGNAME -> home-based fallback keeps the test hermetic.
+		const dir = await ensureSshSocketDir(false, { HOME: tempHome });
+		const expectedDir = join(tempHome, ".ssh", "wm");
+		assertEquals(dir, expectedDir);
+
+		const stat = await Deno.stat(expectedDir);
+		assertEquals(stat.isDirectory, true);
+		if (stat.mode != null) {
+			assertEquals(stat.mode & 0o777, 0o700);
+		}
+
+		// Second call is a no-op and returns the same path.
+		const dir2 = await ensureSshSocketDir();
+		assertEquals(dir2, expectedDir);
+	} finally {
+		await Deno.remove(tempHome, { recursive: true });
+	}
+});
+
+Deno.test("ensureSshSocketDir degrades gracefully when mkdir fails", async () => {
+	resetSocketDirStateForTests();
+	const tempHome = await Deno.makeTempDir();
+	try {
+		// Create a file at the .ssh path so recursive mkdir fails reliably
+		// regardless of the user the tests run as.
+		await Deno.writeTextFile(join(tempHome, ".ssh"), "");
+
+		const dir = await ensureSshSocketDir(true, { HOME: tempHome });
+		assertEquals(dir, null);
+	} finally {
+		await Deno.remove(tempHome, { recursive: true });
+	}
+});
+
+Deno.test("GitManager still reports non-repository when socket dir creation fails", async () => {
+	resetSocketDirStateForTests();
+	const tempHome = await Deno.makeTempDir();
+	const originalHome = Deno.env.get("HOME");
+	Deno.env.set("HOME", tempHome);
+	try {
+		await Deno.writeTextFile(join(tempHome, ".ssh"), "");
+
+		const git = new GitManager(tempHome, true);
+		const result = await git.isRepository();
+		assertEquals(result.ok, true);
+		assertEquals(result.value, false);
+	} finally {
+		if (originalHome !== undefined) {
+			Deno.env.set("HOME", originalHome);
+		} else {
+			Deno.env.delete("HOME");
+		}
+		await Deno.remove(tempHome, { recursive: true });
+	}
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,7 +29,7 @@ cli
 		"-j, --concurrency <concurrency:number>",
 		"Number of concurrent operations",
 		{
-			default: 4,
+			default: 8,
 		},
 	)
 	.option("-y, --yes", "Accept all changes")
@@ -57,7 +57,7 @@ cli
 		"-j, --concurrency <concurrency:number>",
 		"Number of concurrent operations",
 		{
-			default: 4,
+			default: 8,
 		},
 	)
 	.action(async (options) => {
@@ -81,7 +81,7 @@ cli
 		"-j, --concurrency <concurrency:number>",
 		"Number of concurrent operations",
 		{
-			default: 4,
+			default: 8,
 		},
 	)
 	.option("-y, --yes", "Skip sync confirmation prompt")
@@ -129,7 +129,7 @@ cli
 		"-j, --concurrency <concurrency:number>",
 		"Number of concurrent operations",
 		{
-			default: 4,
+			default: 8,
 		},
 	)
 	.option("-b, --branch <branch:string>", "Git branch to checkout", {
@@ -174,7 +174,7 @@ cli
 		"-j, --concurrency <concurrency:number>",
 		"Number of concurrent operations",
 		{
-			default: 4,
+			default: 8,
 		},
 	)
 	.option("--json", "Output in JSON format", { default: false })

--- a/src/cmds/sync.ts
+++ b/src/cmds/sync.ts
@@ -1,4 +1,4 @@
-import { blue, green, yellow } from "@std/fmt/colors";
+import { blue, gray, green, yellow } from "@std/fmt/colors";
 import { Result } from "typescript-result";
 import type { AppContext } from "../composition.ts";
 import { AppError } from "../libs/app-error.ts";
@@ -25,7 +25,7 @@ export async function syncCommand(ctx: AppContext, options: SyncCommandOption): 
 	return Result.ok();
 }
 
-function presentSyncReport(report: SyncReport, debug: boolean): void {
+export function presentSyncReport(report: SyncReport, debug: boolean): void {
 	console.log(blue(`📄 Config file: ${report.configPath}`));
 	console.log(blue(`📁 Workspace root: ${report.workspaceRoot}`));
 
@@ -35,6 +35,8 @@ function presentSyncReport(report: SyncReport, debug: boolean): void {
 
 	console.log(blue(`✅ Active workspaces: ${report.activeCount}`));
 	console.log(blue(`❌ Inactive workspaces: ${report.inactiveCount}`));
+	console.log(blue(`⬇️  Updated: ${report.updatedCount}`));
+	console.log(blue(`✓ Up-to-date: ${report.upToDateCount}`));
 
 	if (report.goWorkspaceSetup) {
 		console.log(green("✅ Go workspace setup successful"));
@@ -51,6 +53,18 @@ function presentSyncReport(report: SyncReport, debug: boolean): void {
 		for (const hookResult of workspaceResult.results) {
 			processHookResult(hookResult, workspaceResult.path);
 		}
+	}
+
+	if (debug) {
+		console.log(gray("⏱ Sync timing:"));
+		for (const [path, ms] of Object.entries(report.timing.perWorkspaceMs)) {
+			console.log(gray(`  ⏱ ${path}: ${ms}ms`));
+		}
+		console.log(gray(`  removal: ${report.timing.removalMs}ms`));
+		console.log(gray(`  sync: ${report.timing.syncMs}ms`));
+		console.log(gray(`  go workspace: ${report.timing.goWorkspaceMs}ms`));
+		console.log(gray(`  hooks: ${report.timing.hooksMs}ms`));
+		console.log(gray(`  total: ${report.timing.totalMs}ms`));
 	}
 }
 

--- a/src/cmds/sync_test.ts
+++ b/src/cmds/sync_test.ts
@@ -1,0 +1,47 @@
+import { assert } from "@std/assert";
+import { presentSyncReport } from "./sync.ts";
+import type { SyncReport } from "../services/sync.ts";
+
+function makeReport(overrides: Partial<SyncReport> = {}): SyncReport {
+	return {
+		workspaceRoot: "/ws",
+		configPath: "/ws/workspace.yml",
+		activeCount: 5,
+		inactiveCount: 1,
+		removedCount: 1,
+		syncedCount: 5,
+		updatedCount: 2,
+		upToDateCount: 3,
+		skippedDetachedCount: 0,
+		goWorkspaceSetup: false,
+		globalHookResults: [],
+		workspaceHookResults: [],
+		timing: {
+			totalMs: 100,
+			removalMs: 10,
+			syncMs: 50,
+			goWorkspaceMs: 0,
+			hooksMs: 0,
+			perWorkspaceMs: {},
+		},
+		...overrides,
+	};
+}
+
+Deno.test("presentSyncReport prints updated and up-to-date counts", () => {
+	const logs: string[] = [];
+	const originalLog = console.log;
+	console.log = (...args: unknown[]) => {
+		logs.push(args.map((arg) => String(arg)).join(" "));
+	};
+
+	try {
+		presentSyncReport(makeReport(), false);
+	} finally {
+		console.log = originalLog;
+	}
+
+	const output = logs.join("\n");
+	assert(output.includes("Updated: 2"), `expected updated count, got: ${output}`);
+	assert(output.includes("Up-to-date: 3"), `expected up-to-date count, got: ${output}`);
+});

--- a/src/composition.ts
+++ b/src/composition.ts
@@ -57,7 +57,7 @@ export function createAppContext(options?: BootstrapOptions): AppContext {
 	const createConfigStore = (configPath: string) => new ConfigManager(configPath);
 	const createDiscovery = (opts: WorkspaceDiscoveryOptions) => new WorkspaceDiscovery({ ...opts, startDir: opts.startDir ?? startDir });
 	const createHookRunner = (hookDebug?: boolean) => new HookExecutor(hookDebug ?? debug);
-	const gitFactory: GitPortFactory = (cwd: string) => new GitManager(cwd);
+	const gitFactory: GitPortFactory = (cwd: string) => new GitManager(cwd, debug);
 	const goWorkFactory: GoWorkPortFactory = (cwd: string) => new GoWork(cwd);
 
 	const statusService = new StatusService({

--- a/src/composition_test.ts
+++ b/src/composition_test.ts
@@ -53,6 +53,7 @@ Deno.test("gitFactory returns an object assignable to GitPort", () => {
 	assert(typeof git.checkoutBranch === "function");
 	assert(typeof git.getCurrentBranch === "function");
 	assert(typeof git.pullOriginBranch === "function");
+	assert(typeof git.syncBranch === "function");
 	assert(typeof git.isRepository === "function");
 	assert(typeof git.isDetachedHead === "function");
 	assert(typeof git.isHeadBehindBranch === "function");

--- a/src/integration/git_fixture.ts
+++ b/src/integration/git_fixture.ts
@@ -324,6 +324,130 @@ export async function buildUninitializedFixture(opts?: {
 	});
 }
 
+export type MultiSubmoduleFixture = {
+	workspaceRoot: string;
+	configPath: string;
+	submodulePaths: string[];
+	upstreamDirs: string[];
+	branch: string;
+	cleanup: () => Promise<void>;
+};
+
+/**
+ * Build a superproject with N registered but uninitialized submodules.
+ * Each submodule directory exists as an empty dir inside a git worktree.
+ */
+export async function buildMultiSubmoduleUninitializedFixture(opts?: {
+	count?: number;
+	branch?: string;
+}): Promise<MultiSubmoduleFixture> {
+	const count = opts?.count ?? 2;
+	const branch = opts?.branch ?? "feature";
+	const tempRoot = await Deno.makeTempDir({ prefix: "wm-integration-" });
+
+	const upstreamDirs: string[] = [];
+	const submoduleNames: string[] = [];
+
+	try {
+		// Create upstream repos
+		for (let i = 0; i < count; i++) {
+			const upstreamDir = `${tempRoot}/upstream-${i}`;
+			const name = `sub-${i}`;
+			submoduleNames.push(name);
+			upstreamDirs.push(upstreamDir);
+
+			await Deno.mkdir(upstreamDir);
+			const initResult = await runGit(upstreamDir, ["init"]);
+			if (!initResult.ok) {
+				throw initResult.error;
+			}
+			await configureGitUser(upstreamDir);
+			await createCommit(upstreamDir, "c1");
+			const checkoutResult = await runGit(upstreamDir, ["checkout", "-b", branch]);
+			if (!checkoutResult.ok) {
+				throw checkoutResult.error;
+			}
+			await createCommit(upstreamDir, "c2");
+		}
+
+		// Create superproject and add all submodules
+		const superDir = `${tempRoot}/super`;
+		await Deno.mkdir(superDir);
+		const superInit = await runGit(superDir, ["init"]);
+		if (!superInit.ok) {
+			throw superInit.error;
+		}
+		await configureGitUser(superDir);
+
+		for (let i = 0; i < count; i++) {
+			const addResult = await runGit(superDir, [
+				"submodule",
+				"add",
+				"-b",
+				branch,
+				upstreamDirs[i],
+				submoduleNames[i],
+			]);
+			if (!addResult.ok) {
+				throw addResult.error;
+			}
+		}
+
+		const addResult = await runGit(superDir, ["add", "."]);
+		if (!addResult.ok) {
+			throw addResult.error;
+		}
+		const commitResult = await runGit(superDir, ["commit", "-m", "add submodules"]);
+		if (!commitResult.ok) {
+			throw commitResult.error;
+		}
+
+		// Create worktree so submodules are not auto-initialized
+		const workspaceRoot = `${tempRoot}/worktree`;
+		const worktreeResult = await runGit(superDir, ["worktree", "add", workspaceRoot, "HEAD"]);
+		if (!worktreeResult.ok) {
+			throw worktreeResult.error;
+		}
+
+		const submodulePaths = submoduleNames.map((name) => `${workspaceRoot}/${name}`);
+
+		// Write workspace.yml with all submodules
+		const configPath = `${workspaceRoot}/workspace.yml`;
+		const config: WorkspaceConfig = {
+			workspaces: submoduleNames.map((name) => ({
+				url: `file://${upstreamDirs[submoduleNames.indexOf(name)]}`,
+				path: name,
+				branch,
+				isGolang: false,
+				active: true,
+			})),
+		};
+		await Deno.writeTextFile(configPath, stringify(config as Record<string, unknown>));
+
+		return {
+			workspaceRoot,
+			configPath,
+			submodulePaths,
+			upstreamDirs,
+			branch,
+			cleanup: async () => {
+				try {
+					await Deno.remove(tempRoot, { recursive: true });
+				} catch {
+					// ignore cleanup errors
+				}
+			},
+		};
+	} catch (e) {
+		try {
+			await Deno.remove(tempRoot, { recursive: true });
+		} catch {
+			// ignore
+		}
+		throw e;
+	}
+}
+
 /**
  * Overwrite workspace.yml with a different branch value (for TC-4 save test).
  */

--- a/src/integration/submodule_batch_init_test.ts
+++ b/src/integration/submodule_batch_init_test.ts
@@ -1,0 +1,40 @@
+/**
+ * Integration test for batched submodule initialization.
+ *
+ * Verifies that GitManager.submoduleInitMany clones multiple registered
+ * submodules in a single git invocation.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { GitManager } from "../adapters/git.ts";
+import { buildMultiSubmoduleUninitializedFixture } from "./git_fixture.ts";
+
+Deno.test("submodule batch init — clones multiple registered submodules in one call", async () => {
+	const fixture = await buildMultiSubmoduleUninitializedFixture({ count: 2, branch: "feature" });
+	try {
+		const rootGit = new GitManager(fixture.workspaceRoot);
+
+		// Precondition: submodule dirs are not repositories
+		for (const path of fixture.submodulePaths) {
+			const before = await new GitManager(path).isRepository();
+			assert(before.ok, `isRepository failed before batch init: ${!before.ok ? before.error.message : ""}`);
+			assertEquals(before.value, false, `expected ${path} not to be a repo before batch init`);
+		}
+
+		const result = await rootGit.submoduleInitMany(
+			fixture.submodulePaths.map((p) => p.slice(fixture.workspaceRoot.length + 1)),
+			2,
+		);
+
+		assert(result.ok, `submoduleInitMany failed: ${!result.ok ? result.error.message : ""}`);
+
+		// Postcondition: all submodule dirs are now repositories
+		for (const path of fixture.submodulePaths) {
+			const after = await new GitManager(path).isRepository();
+			assert(after.ok, `isRepository failed after batch init: ${!after.ok ? after.error.message : ""}`);
+			assertEquals(after.value, true, `expected ${path} to be a repo after batch init`);
+		}
+	} finally {
+		await fixture.cleanup();
+	}
+});

--- a/src/integration/submodule_readiness_test.ts
+++ b/src/integration/submodule_readiness_test.ts
@@ -508,15 +508,15 @@ Deno.test(
 		assertEquals(initCalls.length, 1, "should call submoduleInit on root");
 		assertEquals(initCalls[0].args[0], "repo", "should init the correct path");
 
-		// After init, the submodule git should proceed with checkout/pull
+		// After init, the submodule git should proceed with checkout/sync
 		const subGit = getGit(repoPath);
 		assert(subGit !== undefined);
-		// Should have called checkoutBranch (to switch from main to feature) and pullOriginBranch
+		// Should have called checkoutBranch (to switch from main to feature) and syncBranch
 		const checkoutCalls = subGit.calls.filter((c) => c.method === "checkoutBranch");
-		const pullCalls = subGit.calls.filter((c) => c.method === "pullOriginBranch");
+		const syncCalls = subGit.calls.filter((c) => c.method === "syncBranch");
 		assert(checkoutCalls.length >= 1, "should checkout branch after init");
 		assertEquals(checkoutCalls[0].args[0], "feature", "should checkout to feature branch");
-		assert(pullCalls.length >= 1, "should pull after init");
+		assert(syncCalls.length >= 1, "should sync branch after init");
 	},
 );
 

--- a/src/integration/sync_branch_test.ts
+++ b/src/integration/sync_branch_test.ts
@@ -1,0 +1,157 @@
+/**
+ * Integration tests for GitManager.syncBranch().
+ *
+ * Covers:
+ * - P0: up-to-date branch performs no merge and returns { updated: false }
+ * - P0: behind branch fast-forwards and returns { updated: true }
+ * - P0: diverged histories return GIT_FAILED, leave HEAD unchanged, no MERGE_HEAD
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { buildNormalFixture } from "./git_fixture.ts";
+import { GitManager } from "../adapters/git.ts";
+import { AppErrorCode } from "../libs/app-error.ts";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function runGit(cwd: string, args: string[]): Promise<void> {
+	const output = await new Deno.Command("git", {
+		args,
+		cwd,
+		stdout: "null",
+		stderr: "piped",
+	}).output();
+	assertEquals(output.success, true, `git ${args.join(" ")} failed in ${cwd}`);
+}
+
+async function gitRevParse(cwd: string, ref: string): Promise<string> {
+	const output = await new Deno.Command("git", {
+		args: ["rev-parse", ref],
+		cwd,
+		stdout: "piped",
+		stderr: "piped",
+	}).output();
+	assertEquals(output.success, true, `git rev-parse ${ref} failed in ${cwd}`);
+	return new TextDecoder().decode(output.stdout).trim().toLowerCase();
+}
+
+async function gitDir(cwd: string): Promise<string> {
+	const output = await new Deno.Command("git", {
+		args: ["rev-parse", "--git-dir"],
+		cwd,
+		stdout: "piped",
+		stderr: "piped",
+	}).output();
+	assertEquals(output.success, true, `git rev-parse --git-dir failed in ${cwd}`);
+	const raw = new TextDecoder().decode(output.stdout).trim();
+	// --git-dir may return a relative path (e.g. ".git" or "../.git/modules/sub");
+	// resolve it relative to cwd so Deno.stat works.
+	return raw.startsWith("/") ? raw : `${cwd}/${raw}`;
+}
+
+async function configureGitUser(cwd: string): Promise<void> {
+	await runGit(cwd, ["config", "user.email", "test@test.test"]);
+	await runGit(cwd, ["config", "user.name", "Test User"]);
+}
+
+async function createCommit(cwd: string, message: string): Promise<void> {
+	const timestamp = Date.now();
+	await Deno.writeTextFile(`${cwd}/commit-${timestamp}.txt`, message);
+	await runGit(cwd, ["add", "."]);
+	await runGit(cwd, ["commit", "-m", message]);
+}
+
+async function mergeHeadExists(cwd: string): Promise<boolean> {
+	const dir = await gitDir(cwd);
+	try {
+		await Deno.stat(`${dir}/MERGE_HEAD`);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test Cases
+// ---------------------------------------------------------------------------
+
+Deno.test(
+	"syncBranch — up-to-date branch performs no merge (TC-01)",
+	async () => {
+		const fixture = await buildNormalFixture({ branch: "feature" });
+		try {
+			const git = new GitManager(fixture.submodulePath);
+			const headBefore = await gitRevParse(fixture.submodulePath, "HEAD");
+
+			const result = await git.syncBranch("feature");
+
+			assert(result.ok, `syncBranch failed: ${!result.ok ? result.error.message : ""}`);
+			assertEquals(result.value.updated, false, "expected updated=false for up-to-date branch");
+
+			const headAfter = await gitRevParse(fixture.submodulePath, "HEAD");
+			assertEquals(headAfter, headBefore, "HEAD must not move when already up-to-date");
+
+			assertEquals(await mergeHeadExists(fixture.submodulePath), false, "no merge should be in progress");
+		} finally {
+			await fixture.cleanup();
+		}
+	},
+);
+
+Deno.test(
+	"syncBranch — behind branch fast-forwards (TC-02)",
+	async () => {
+		const fixture = await buildNormalFixture({ branch: "feature" });
+		try {
+			// Pre-condition: reset local branch one commit behind the remote tip.
+			await runGit(fixture.submodulePath, ["reset", "--hard", "HEAD~1"]);
+
+			const git = new GitManager(fixture.submodulePath);
+			const result = await git.syncBranch("feature");
+
+			assert(result.ok, `syncBranch failed: ${!result.ok ? result.error.message : ""}`);
+			assertEquals(result.value.updated, true, "expected updated=true for behind branch");
+
+			const headAfter = await gitRevParse(fixture.submodulePath, "HEAD");
+			const originFeature = await gitRevParse(fixture.submodulePath, "origin/feature");
+			assertEquals(headAfter, originFeature, "HEAD must equal origin/feature after fast-forward");
+		} finally {
+			await fixture.cleanup();
+		}
+	},
+);
+
+Deno.test(
+	"syncBranch — diverged histories error without merging (TC-03)",
+	async () => {
+		const fixture = await buildNormalFixture({ branch: "feature" });
+		try {
+			// Local-only commit in the submodule.
+			await configureGitUser(fixture.submodulePath);
+			await createCommit(fixture.submodulePath, "local-only");
+			const headBefore = await gitRevParse(fixture.submodulePath, "HEAD");
+
+			// Remote-only commit in upstream so origin/feature diverges from local.
+			await createCommit(fixture.upstreamDir, "remote-only");
+
+			const git = new GitManager(fixture.submodulePath);
+			const result = await git.syncBranch("feature");
+
+			assert(!result.ok, "expected syncBranch to fail for diverged histories");
+			assertEquals(result.error.code, AppErrorCode.GIT_FAILED, "expected GIT_FAILED error code");
+			assert(
+				result.error.message.toLowerCase().includes("fast-forward") || result.error.message.toLowerCase().includes("diverged"),
+				`error message should mention fast-forward or diverged, got: ${result.error.message}`,
+			);
+
+			const headAfter = await gitRevParse(fixture.submodulePath, "HEAD");
+			assertEquals(headAfter, headBefore, "HEAD must not change on diverged sync failure");
+
+			assertEquals(await mergeHeadExists(fixture.submodulePath), false, "no MERGE_HEAD should be left behind");
+		} finally {
+			await fixture.cleanup();
+		}
+	},
+);

--- a/src/libs/concurrent.ts
+++ b/src/libs/concurrent.ts
@@ -1,37 +1,49 @@
 import { Result } from "typescript-result";
 
 /**
- * Process items concurrently with a specified concurrency limit
+ * Process items concurrently with a specified concurrency limit.
+ *
+ * Workers share an index cursor into the input array; as soon as any worker
+ * finishes an item it picks up the next available one. When an item fails, no
+ * new items are started (in-flight items are allowed to finish) and the first
+ * error by input index is returned.
+ *
  * @param items - Array of items to process
  * @param processor - Function to process each item
- * @param concurrency - Maximum number of concurrent operations (default: 4)
+ * @param concurrency - Maximum number of concurrent operations (default: 8)
  * @returns Result indicating success or failure
  */
 export async function processConcurrently<T, E extends Error>(
 	items: T[],
 	processor: (item: T) => Promise<Result<void, E>>,
-	concurrency: number = 4,
+	concurrency: number = 8,
 ): Promise<Result<void, E>> {
 	if (items.length === 0) {
 		return Result.ok();
 	}
 
-	// Create batches based on concurrency level
-	const batches: T[][] = [];
-	for (let i = 0; i < items.length; i += concurrency) {
-		batches.push(items.slice(i, i + concurrency));
+	const results: Result<void, E>[] = new Array(items.length);
+	let nextIndex = 0;
+	let failed = false;
+
+	async function worker(): Promise<void> {
+		while (nextIndex < items.length && !failed) {
+			const index = nextIndex++;
+			const result = await processor(items[index]);
+			results[index] = result;
+			if (!result.ok) {
+				failed = true;
+			}
+		}
 	}
 
-	// Process each batch concurrently
-	for (const batch of batches) {
-		const promises = batch.map((item) => processor(item));
-		const results = await Promise.all(promises);
+	const workers = Array.from({ length: Math.min(concurrency, items.length) }, () => worker());
+	await Promise.all(workers);
 
-		// Check if any operation failed
-		for (const result of results) {
-			if (!result.ok) {
-				return result as Result<void, E>;
-			}
+	for (let i = 0; i < results.length; i++) {
+		const result = results[i];
+		if (result && !result.ok) {
+			return result as Result<void, E>;
 		}
 	}
 
@@ -39,35 +51,37 @@ export async function processConcurrently<T, E extends Error>(
 }
 
 /**
- * Process items concurrently with a specified concurrency limit, allowing some failures
+ * Process items concurrently with a specified concurrency limit, allowing some failures.
+ *
+ * Workers share an index cursor into the input array and write results back by
+ * input index, so the returned array is in the same order as the input.
+ *
  * @param items - Array of items to process
  * @param processor - Function to process each item
- * @param concurrency - Maximum number of concurrent operations (default: 4)
+ * @param concurrency - Maximum number of concurrent operations (default: 8)
  * @returns Array of results for each item
  */
 export async function processConcurrentlyWithResults<T, R, E extends Error>(
 	items: T[],
 	processor: (item: T) => Promise<Result<R, E>>,
-	concurrency: number = 4,
+	concurrency: number = 8,
 ): Promise<Result<R, E>[]> {
 	if (items.length === 0) {
 		return [];
 	}
 
-	// Create batches based on concurrency level
-	const batches: T[][] = [];
-	for (let i = 0; i < items.length; i += concurrency) {
-		batches.push(items.slice(i, i + concurrency));
+	const results: Result<R, E>[] = new Array(items.length);
+	let nextIndex = 0;
+
+	async function worker(): Promise<void> {
+		while (nextIndex < items.length) {
+			const index = nextIndex++;
+			results[index] = await processor(items[index]);
+		}
 	}
 
-	const allResults: Result<R, E>[] = [];
+	const workers = Array.from({ length: Math.min(concurrency, items.length) }, () => worker());
+	await Promise.all(workers);
 
-	// Process each batch concurrently
-	for (const batch of batches) {
-		const promises = batch.map((item) => processor(item));
-		const results = await Promise.all(promises);
-		allResults.push(...results);
-	}
-
-	return allResults;
+	return results;
 }

--- a/src/libs/concurrent_test.ts
+++ b/src/libs/concurrent_test.ts
@@ -1,0 +1,176 @@
+import { assert, assertEquals, assertFalse } from "@std/assert";
+import { Result } from "typescript-result";
+import { processConcurrently, processConcurrentlyWithResults } from "./concurrent.ts";
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+Deno.test("processConcurrentlyWithResults: concurrency limit is never exceeded", async () => {
+	const items = Array.from({ length: 20 }, (_, i) => i);
+	let active = 0;
+	let maxActive = 0;
+
+	const results = await processConcurrentlyWithResults(
+		items,
+		async (item) => {
+			active++;
+			if (active > maxActive) {
+				maxActive = active;
+			}
+			await sleep(10);
+			active--;
+			return Result.ok(item);
+		},
+		5,
+	);
+
+	assertEquals(results.length, 20);
+	for (let i = 0; i < results.length; i++) {
+		assert(results[i].ok, `expected result ${i} to be ok`);
+		assertEquals(results[i].value, i);
+	}
+	assertEquals(maxActive, 5, `max active concurrency should be 5, got ${maxActive}`);
+});
+
+Deno.test("processConcurrentlyWithResults: results preserve input order", async () => {
+	const items = Array.from({ length: 10 }, (_, i) => i);
+
+	const results = await processConcurrentlyWithResults(
+		items,
+		async (item) => {
+			await sleep(item % 2 === 0 ? 20 : 5);
+			return Result.ok(item);
+		},
+		4,
+	);
+
+	assertEquals(results.length, 10);
+	for (let i = 0; i < results.length; i++) {
+		assert(results[i].ok, `expected result ${i} to be ok`);
+		assertEquals(results[i].value, i);
+	}
+});
+
+Deno.test("processConcurrentlyWithResults: slow item does not convoy later fast items", async () => {
+	// Item durations: one slow (index 0, 400ms) and four fast (10ms each).
+	// Concurrency 2 means the second slot should drain fast items while the
+	// slow item occupies the first slot.
+	const items = [
+		{ duration: 400, index: 0 },
+		{ duration: 10, index: 1 },
+		{ duration: 10, index: 2 },
+		{ duration: 10, index: 3 },
+		{ duration: 10, index: 4 },
+	];
+	const startTimes: number[] = new Array(items.length);
+	const start = performance.now();
+
+	const results = await processConcurrentlyWithResults(
+		items,
+		async (item) => {
+			startTimes[item.index] = performance.now() - start;
+			await sleep(item.duration);
+			return Result.ok(item.index);
+		},
+		2,
+	);
+
+	const elapsed = performance.now() - start;
+
+	assertEquals(results.length, items.length);
+	for (const result of results) {
+		assert(result.ok);
+	}
+
+	// Wall time should be dominated by the slow item, not by batch stalls.
+	assert(elapsed < 500, `expected elapsed < 500ms, got ${elapsed}ms`);
+
+	// All fast items should start before the slow item finishes.
+	for (let i = 1; i < startTimes.length; i++) {
+		assert(startTimes[i] < 400, `expected fast item ${i} to start before slow item finished, started at ${startTimes[i]}ms`);
+	}
+});
+
+Deno.test("processConcurrently: returns first error and stops starting new items", async () => {
+	const processed: number[] = [];
+
+	// Make the failing item finish first so the failure is observed while the
+	// first item is still in flight. This keeps the test deterministic: items
+	// after the failure that had not started must never be processed.
+	const items = [
+		{ label: "ok-slow", duration: 50, index: 0 },
+		{ label: "fail-fast", duration: 10, index: 1 },
+		{ label: "ok-2", duration: 20, index: 2 },
+		{ label: "ok-3", duration: 20, index: 3 },
+		{ label: "ok-4", duration: 20, index: 4 },
+	];
+
+	const result = await processConcurrently(
+		items,
+		async (item) => {
+			processed.push(item.index);
+			await sleep(item.duration);
+			if (item.label === "fail-fast") {
+				return Result.error(new Error("intentional failure"));
+			}
+			return Result.ok();
+		},
+		2,
+	);
+
+	assertFalse(result.ok, "expected an error result");
+	assertEquals(result.error.message, "intentional failure");
+
+	// Items 0 and 1 started immediately. Once item 1 failed, no further items
+	// should have been picked up.
+	assert(processed.includes(0), "expected item 0 to have started");
+	assert(processed.includes(1), "expected item 1 to have started");
+	for (let i = 2; i <= 4; i++) {
+		assertFalse(processed.includes(i), `expected item ${i} to never start`);
+	}
+});
+
+Deno.test("processConcurrently: empty input returns ok", async () => {
+	const result = await processConcurrently<number, Error>([], () => Promise.resolve(Result.ok()), 3);
+	assert(result.ok);
+});
+
+Deno.test("processConcurrentlyWithResults: empty input returns empty array", async () => {
+	const results = await processConcurrentlyWithResults<number, number, Error>([], () => Promise.resolve(Result.ok(0)), 3);
+	assertEquals(results, []);
+});
+
+Deno.test("processConcurrently: first error is returned among multiple failures", async () => {
+	const result = await processConcurrently(
+		["a", "b", "c"],
+		async (item) => {
+			await sleep(5);
+			return Result.error(new Error(`failed: ${item}`));
+		},
+		2,
+	);
+
+	assertFalse(result.ok);
+	assertEquals(result.error.message, "failed: a");
+});
+
+Deno.test("processConcurrentlyWithResults: collects all results including failures", async () => {
+	const results = await processConcurrentlyWithResults(
+		["a", "b", "c"],
+		async (item) => {
+			await sleep(5);
+			if (item === "b") {
+				return Result.error(new Error(`failed: ${item}`));
+			}
+			return Result.ok(item);
+		},
+		2,
+	);
+
+	assertEquals(results.length, 3);
+	assert(results[0].ok);
+	assertEquals(results[0].value, "a");
+	assertFalse(results[1].ok);
+	assertEquals(results[1].error.message, "failed: b");
+	assert(results[2].ok);
+	assertEquals(results[2].value, "c");
+});

--- a/src/libs/git-env.ts
+++ b/src/libs/git-env.ts
@@ -1,0 +1,88 @@
+import { join } from "@std/path";
+
+/** Prefix of the per-user multiplex socket directory under /tmp. */
+export const SSH_SOCKET_TMP_PREFIX = "/tmp/wm-ssh-";
+
+/** Directory name under ~/.ssh used as the fallback socket dir. */
+export const SSH_SOCKET_HOME_DIR_NAME = "wm";
+
+/** How long (in seconds) OpenSSH keeps an idle ControlMaster alive. */
+export const SSH_CONTROL_PERSIST_SECONDS = 60;
+
+/**
+ * Maximum allowed length for the socket directory path.
+ *
+ * macOS limits Unix domain socket paths to 104 bytes (103 usable). ssh
+ * appends "/%C" (41 chars) plus a "." + ~22-char temporary listener suffix
+ * to the ControlPath, so the directory itself must stay well under the
+ * limit: 103 - 64 = 39; we use 38 for headroom.
+ */
+export const MAX_SOCKET_DIR_LENGTH = 38;
+
+function sanitizeUser(user: string): string {
+	return user.replace(/[^A-Za-z0-9_-]/g, "-");
+}
+
+/**
+ * Build the path to the SSH multiplex socket directory.
+ *
+ * Candidates, in order:
+ * 1. `/tmp/wm-ssh-<user>` — short enough for the macOS socket path limit
+ *    even with long usernames/home dirs (uses `USER`/`LOGNAME`, sanitized).
+ * 2. `<home>/.ssh/wm` — fallback when no username is available.
+ *
+ * Returns `null` when no candidate fits within {@link MAX_SOCKET_DIR_LENGTH}
+ * (caller should then skip mux). Candidates that are too long are skipped in
+ * order.
+ */
+export function getSshSocketDir(env: Record<string, string | undefined>): string | null {
+	const candidates: string[] = [];
+
+	const user = env["USER"] ?? env["LOGNAME"];
+	if (user) {
+		const sanitized = sanitizeUser(user);
+		if (sanitized.length > 0) {
+			candidates.push(`${SSH_SOCKET_TMP_PREFIX}${sanitized}`);
+		}
+	}
+
+	const home = env["HOME"] ?? env["USERPROFILE"];
+	if (home) {
+		candidates.push(join(home, ".ssh", SSH_SOCKET_HOME_DIR_NAME));
+	}
+
+	for (const dir of candidates) {
+		if (dir.length <= MAX_SOCKET_DIR_LENGTH) {
+			return dir;
+		}
+	}
+	return null;
+}
+
+/**
+ * Build the environment passed to every git subprocess.
+ *
+ * If the user already provided `GIT_SSH_COMMAND` it is preserved verbatim.
+ * Otherwise, when a socket directory is available, the returned env injects
+ * `GIT_SSH_COMMAND` with OpenSSH ControlMaster options pointing at the
+ * tool-managed socket directory.
+ *
+ * `socketDir` is normally derived from `env` but may be supplied explicitly by
+ * the caller (e.g. after it has ensured the directory exists). Passing `null`
+ * disables mux even when a candidate is present.
+ */
+export function buildGitEnv(
+	env: Record<string, string | undefined>,
+	socketDir: string | null = getSshSocketDir(env),
+): Record<string, string> {
+	if (env["GIT_SSH_COMMAND"]) {
+		return env as Record<string, string>;
+	}
+	if (!socketDir) {
+		return env as Record<string, string>;
+	}
+	return {
+		...env,
+		GIT_SSH_COMMAND: `ssh -o ControlMaster=auto -o ControlPath=${socketDir}/%C -o ControlPersist=${SSH_CONTROL_PERSIST_SECONDS}`,
+	} as Record<string, string>;
+}

--- a/src/libs/git-env_test.ts
+++ b/src/libs/git-env_test.ts
@@ -1,0 +1,68 @@
+import { assertEquals, assertFalse } from "@std/assert";
+import { buildGitEnv, getSshSocketDir, MAX_SOCKET_DIR_LENGTH, SSH_CONTROL_PERSIST_SECONDS } from "./git-env.ts";
+
+Deno.test("buildGitEnv injects GIT_SSH_COMMAND when unset", () => {
+	const env = buildGitEnv({ USER: "u" });
+	assertEquals(
+		env["GIT_SSH_COMMAND"],
+		`ssh -o ControlMaster=auto -o ControlPath=/tmp/wm-ssh-u/%C -o ControlPersist=${SSH_CONTROL_PERSIST_SECONDS}`,
+	);
+});
+
+Deno.test("buildGitEnv preserves user GIT_SSH_COMMAND", () => {
+	const env = buildGitEnv({ USER: "u", GIT_SSH_COMMAND: "ssh -i /key" });
+	assertEquals(env["GIT_SSH_COMMAND"], "ssh -i /key");
+});
+
+Deno.test("buildGitEnv skips mux when no socket dir candidate exists", () => {
+	const env = buildGitEnv({});
+	assertFalse("GIT_SSH_COMMAND" in env);
+});
+
+Deno.test("buildGitEnv skips mux when socketDir is null even with candidates", () => {
+	const env = buildGitEnv({ USER: "u" }, null);
+	assertFalse("GIT_SSH_COMMAND" in env);
+});
+
+Deno.test("getSshSocketDir prefers short /tmp dir from USER", () => {
+	assertEquals(getSshSocketDir({ USER: "ball6847", HOME: "/home/ball6847" }), "/tmp/wm-ssh-ball6847");
+});
+
+Deno.test("getSshSocketDir falls back to LOGNAME when USER unset", () => {
+	assertEquals(getSshSocketDir({ LOGNAME: "u" }), "/tmp/wm-ssh-u");
+});
+
+Deno.test("getSshSocketDir sanitizes special characters in username", () => {
+	assertEquals(getSshSocketDir({ USER: "weird user@corp" }), "/tmp/wm-ssh-weird-user-corp");
+});
+
+Deno.test("getSshSocketDir falls back to home-based dir when no username", () => {
+	assertEquals(getSshSocketDir({ HOME: "/home/u" }), "/home/u/.ssh/wm");
+});
+
+Deno.test("getSshSocketDir uses USERPROFILE as home fallback", () => {
+	assertEquals(getSshSocketDir({ USERPROFILE: "/users/u" }), "/users/u/.ssh/wm");
+});
+
+Deno.test("getSshSocketDir returns null when no candidate exists", () => {
+	assertEquals(getSshSocketDir({}), null);
+});
+
+Deno.test("getSshSocketDir skips overlong candidates in order", () => {
+	// Username so long that the /tmp candidate exceeds the limit; the
+	// home-based fallback is short enough to be used instead.
+	const longUser = "u".repeat(MAX_SOCKET_DIR_LENGTH);
+	assertEquals(getSshSocketDir({ USER: longUser, HOME: "/home/u" }), "/home/u/.ssh/wm");
+});
+
+Deno.test("getSshSocketDir returns null when every candidate is too long", () => {
+	const longUser = "u".repeat(MAX_SOCKET_DIR_LENGTH);
+	const longHome = "/" + "h".repeat(MAX_SOCKET_DIR_LENGTH);
+	assertEquals(getSshSocketDir({ USER: longUser, HOME: longHome }), null);
+});
+
+Deno.test("getSshSocketDir result always fits within the macOS socket path budget", () => {
+	// 103 usable bytes - 41 ("/%C") - 23 ("." + temp suffix) = 39 max for dir.
+	const dir = getSshSocketDir({ USER: "ball6847", HOME: "/Users/ball6847" });
+	assertEquals(dir !== null && dir.length <= MAX_SOCKET_DIR_LENGTH, true);
+});

--- a/src/ports/git.ts
+++ b/src/ports/git.ts
@@ -1,6 +1,13 @@
 import type { Result } from "typescript-result";
 import type { AppError } from "../libs/app-error.ts";
 
+export type SyncBranchResult = { updated: boolean };
+
+export type BranchState = {
+	detached: boolean;
+	branch: string | null; // null when detached
+};
+
 export type GitPort = {
 	submoduleAdd(url: string, path: string, branch?: string): Promise<Result<void, AppError>>;
 	submoduleRemove(path: string): Promise<Result<void, AppError>>;
@@ -10,13 +17,30 @@ export type GitPort = {
 	 * Runs `git submodule update --init <path>`.
 	 */
 	submoduleInit(path: string): Promise<Result<void, AppError>>;
+	/**
+	 * Initialize/clone multiple submodules in one batched, parallel command.
+	 * Must be called from the workspace root (superproject).
+	 * Runs `git submodule update --init --jobs=<jobs> -- <paths...>`.
+	 * Only works for submodules registered in .gitmodules; a non-zero exit
+	 * indicates one or more paths failed (partial success is possible) —
+	 * callers must re-verify each path individually.
+	 */
+	submoduleInitMany(paths: string[], jobs: number): Promise<Result<void, AppError>>;
 	checkoutBranch(branch: string): Promise<Result<void, AppError>>;
 	getCurrentBranch(): Promise<Result<string, AppError>>;
 	/**
 	 * Returns true if HEAD is in detached state.
 	 * Uses `git symbolic-ref --quiet --short HEAD`: exit 0 -> not detached, exit non-zero -> detached.
+	 * @deprecated Prefer {@link getBranchState} when both detached state and branch name are needed.
 	 */
 	isDetachedHead(): Promise<Result<boolean, AppError>>;
+	/**
+	 * Returns detached state and branch name from a single git invocation.
+	 * Performs exactly one `git symbolic-ref --short HEAD`:
+	 * - exit 0 -> { detached: false, branch: <stdout trimmed> }
+	 * - exit non-zero -> { detached: true, branch: null }
+	 */
+	getBranchState(): Promise<Result<BranchState, AppError>>;
 	/**
 	 * Returns true if HEAD is contained in the given branch's history — i.e. HEAD is
 	 * an ancestor of (or equal to) the branch tip — so re-attaching a detached HEAD
@@ -31,10 +55,16 @@ export type GitPort = {
 	getHeadSha(): Promise<Result<string, AppError>>;
 	pullOriginBranch(branch: string): Promise<Result<void, AppError>>;
 	/**
+	 * Fetches `origin/<branch>`, compares HEAD to `origin/<branch>`, and fast-forwards
+	 * the local branch only when HEAD is behind. Never creates merge commits.
+	 * Returns `{ updated: true }` when HEAD moved, `{ updated: false }` when already
+	 * up-to-date.
+	 */
+	syncBranch(branch: string): Promise<Result<SyncBranchResult, AppError>>;
+	/**
 	 * Returns true if and only if cwd is the **root** of a git work tree.
-	 * This means:
-	 * - `git rev-parse --git-dir` succeeds (basic repo check), AND
-	 * - `git rev-parse --show-toplevel` resolves to `cwd`
+	 * This means `git rev-parse --show-toplevel` succeeds and resolves to `cwd`
+	 * (compared via realpath on both sides).
 	 *
 	 * This prevents false positives for uninitialized submodule directories
 	 * inside a superproject (git would otherwise walk up to parent repo).

--- a/src/services/status.ts
+++ b/src/services/status.ts
@@ -64,7 +64,7 @@ export class StatusService {
 
 		const { workspaceRoot, configPath } = discoverResult.value;
 		const debug = input.debug ?? false;
-		const concurrency = input.concurrency ?? 4;
+		const concurrency = input.concurrency ?? 8;
 		const verbose = input.verbose ?? false;
 
 		const configStore = this.deps.createConfigStore(configPath);

--- a/src/services/sync.ts
+++ b/src/services/sync.ts
@@ -12,6 +12,15 @@ import type { WorkspaceConfigItem } from "../types/config.ts";
 import { blue, green, red, yellow } from "@std/fmt/colors";
 import { WorkspaceManager } from "./workspace-manager.ts";
 
+export type SyncTiming = {
+	totalMs: number;
+	removalMs: number;
+	syncMs: number;
+	goWorkspaceMs: number;
+	hooksMs: number;
+	perWorkspaceMs: Record<string, number>;
+};
+
 export type SyncReport = {
 	workspaceRoot: string;
 	configPath: string;
@@ -19,13 +28,16 @@ export type SyncReport = {
 	inactiveCount: number;
 	removedCount: number;
 	syncedCount: number;
+	updatedCount: number;
+	upToDateCount: number;
 	skippedDetachedCount: number;
 	goWorkspaceSetup: boolean;
 	globalHookResults: HookExecutionResult[];
 	workspaceHookResults: Array<{ path: string; results: HookExecutionResult[] }>;
+	timing: SyncTiming;
 };
 
-type SyncSingleResult = { skippedDetached: boolean };
+type SyncSingleResult = { path: string; skippedDetached: boolean; updated: boolean; elapsedMs: number };
 
 export type SyncServiceDeps = {
 	createDiscovery(options: WorkspaceDiscoveryOptions): WorkspaceDiscoveryPort;
@@ -58,8 +70,9 @@ export class SyncService {
 		}
 
 		const { workspaceRoot, configPath } = discoverResult.value;
-		const concurrency = input.concurrency ?? 4;
+		const concurrency = input.concurrency ?? 8;
 		const debug = input.debug ?? false;
+		const totalStart = performance.now();
 
 		const configStore = this.deps.createConfigStore(configPath);
 		const configResult = await configStore.getWorkspaceConfig(workspaceRoot);
@@ -82,15 +95,26 @@ export class SyncService {
 			inactiveCount: inactiveWorkspaces.length,
 			removedCount: 0,
 			syncedCount: 0,
+			updatedCount: 0,
+			upToDateCount: 0,
 			skippedDetachedCount: 0,
 			goWorkspaceSetup: false,
 			globalHookResults: [],
 			workspaceHookResults: [],
+			timing: {
+				totalMs: 0,
+				removalMs: 0,
+				syncMs: 0,
+				goWorkspaceMs: 0,
+				hooksMs: 0,
+				perWorkspaceMs: {},
+			},
 		};
 
 		const workspaceManager = new WorkspaceManager(workspaceRoot, this.deps.goWorkFactory, this.deps.gitFactory);
 
 		if (inactiveWorkspaces.length > 0) {
+			const removalStart = performance.now();
 			console.log(yellow(`Removing ${inactiveWorkspaces.length} inactive workspaces...`));
 			const removeResult = await processConcurrently(
 				inactiveWorkspaces,
@@ -103,6 +127,7 @@ export class SyncService {
 				},
 				concurrency,
 			);
+			report.timing.removalMs = Math.round(performance.now() - removalStart);
 
 			if (!removeResult.ok) {
 				return Result.error(removeResult.error);
@@ -110,6 +135,49 @@ export class SyncService {
 		}
 
 		if (activeWorkspaces.length > 0) {
+			const syncStart = performance.now();
+
+			// Phase A: classify active workspaces into pending init and ready
+			const classifyResults = await processConcurrentlyWithResults(
+				activeWorkspaces,
+				async (workspace) => await this.classifyWorkspace(workspace, workspaceRoot),
+				concurrency,
+			);
+
+			const pendingInit: WorkspaceConfigItem[] = [];
+			for (const result of classifyResults) {
+				if (!result.ok) {
+					return Result.error(result.error);
+				}
+				if (result.value.pendingInit) {
+					pendingInit.push(result.value.workspace);
+				}
+			}
+
+			// Phase B: one batched init for all pending submodules registered in .gitmodules
+			if (pendingInit.length > 0) {
+				const rootGit = this.deps.gitFactory(workspaceRoot);
+				const pendingPaths = pendingInit.map((workspace) => workspace.path);
+				console.log(blue(`📥 Initializing ${pendingInit.length} submodules (jobs: ${concurrency})...`));
+				const batchResult = await rootGit.submoduleInitMany(pendingPaths, concurrency);
+				if (!batchResult.ok) {
+					console.log(yellow(`⚠️  Batch submodule initialization failed for some paths; handling individually...`));
+				}
+
+				// Phase C: re-verify each pending path and fall back to checkout for those still missing
+				const verifyResults = await processConcurrentlyWithResults(
+					pendingInit,
+					async (workspace) => await this.checkoutIfMissing(workspace, workspaceRoot, workspaceManager),
+					concurrency,
+				);
+
+				for (const result of verifyResults) {
+					if (!result.ok) {
+						return Result.error(result.error);
+					}
+				}
+			}
+
 			console.log(blue(`Syncing ${activeWorkspaces.length} active workspaces...`));
 			const syncResults = await processConcurrentlyWithResults(
 				activeWorkspaces,
@@ -122,15 +190,24 @@ export class SyncService {
 					return Result.error(result.error);
 				}
 				report.syncedCount++;
+				if (result.value.updated) {
+					report.updatedCount++;
+				} else if (!result.value.skippedDetached) {
+					report.upToDateCount++;
+				}
+				report.timing.perWorkspaceMs[result.value.path] = result.value.elapsedMs;
 				if (result.value.skippedDetached) {
 					report.skippedDetachedCount++;
 				}
 			}
+			report.timing.syncMs = Math.round(performance.now() - syncStart);
 		}
 
 		const goAdd = goModulePaths(activeWorkspaces);
 		const goRemove = goModulePaths(inactiveWorkspaces);
+		const goWorkspaceStart = performance.now();
 		const goResult = await workspaceManager.setupGoWorkspace(goAdd, goRemove);
+		report.timing.goWorkspaceMs = Math.round(performance.now() - goWorkspaceStart);
 		report.goWorkspaceSetup = goResult.ok;
 		if (!goResult.ok) {
 			console.log(yellow(`⚠️  Go workspace setup failed: ${goResult.error.message}`));
@@ -138,6 +215,7 @@ export class SyncService {
 
 		const hookExecutor = this.deps.createHookRunner(debug);
 		const hookContext: HookContext = { root: workspaceRoot, path: workspaceRoot };
+		const hooksStart = performance.now();
 
 		if (config.hooks?.postSyncHooks?.length) {
 			console.log(blue(`Executing ${config.hooks.postSyncHooks.length} global post-sync hooks...`));
@@ -175,7 +253,53 @@ export class SyncService {
 			}
 		}
 
+		report.timing.hooksMs = Math.round(performance.now() - hooksStart);
+		report.timing.totalMs = Math.round(performance.now() - totalStart);
 		return Result.ok(report);
+	}
+
+	private async classifyWorkspace(
+		workspace: WorkspaceConfigItem,
+		workspaceRoot: string,
+	): Promise<Result<{ workspace: WorkspaceConfigItem; pendingInit: boolean }, AppError>> {
+		const workspacePath = workspaceDirectory(workspaceRoot, workspace.path);
+		const dir = await this.deps.fileSystem.isDir(workspacePath);
+		if (!dir.ok) {
+			return Result.ok({ workspace, pendingInit: true });
+		}
+
+		const subGit = this.deps.gitFactory(workspacePath);
+		const isRepo = await subGit.isRepository();
+		if (!isRepo.ok) {
+			return Result.error(isRepo.error);
+		}
+
+		return Result.ok({ workspace, pendingInit: !isRepo.value });
+	}
+
+	private async checkoutIfMissing(
+		workspace: WorkspaceConfigItem,
+		workspaceRoot: string,
+		workspaceManager: WorkspaceManager,
+	): Promise<Result<void, AppError>> {
+		const workspacePath = workspaceDirectory(workspaceRoot, workspace.path);
+		const subGit = this.deps.gitFactory(workspacePath);
+		const isRepo = await subGit.isRepository();
+		if (!isRepo.ok) {
+			return Result.error(isRepo.error);
+		}
+
+		if (!isRepo.value) {
+			console.log(yellow(`📥 Checking out workspace: ${workspace.path}`));
+			const checkout = await workspaceManager.checkoutWorkspace(workspace.url, workspace.path, workspace.branch);
+			if (!checkout.ok) {
+				console.log(red(`❌ Failed to check out workspace: ${workspace.path}: ${checkout.error.message}`));
+				return Result.error(checkout.error);
+			}
+			console.log(green(`✅ Successfully checked out workspace: ${workspace.path}`));
+		}
+
+		return Result.ok();
 	}
 
 	private async syncSingleWorkspace(
@@ -183,6 +307,25 @@ export class SyncService {
 		workspaceRoot: string,
 		workspaceManager: WorkspaceManager,
 	): Promise<Result<SyncSingleResult, AppError>> {
+		const start = performance.now();
+		const result = await this.syncSingleWorkspaceImpl(workspace, workspaceRoot, workspaceManager);
+		const elapsedMs = Math.round(performance.now() - start);
+		if (!result.ok) {
+			return result;
+		}
+		return Result.ok({
+			path: workspace.path,
+			skippedDetached: result.value.skippedDetached,
+			updated: result.value.updated,
+			elapsedMs,
+		});
+	}
+
+	private async syncSingleWorkspaceImpl(
+		workspace: WorkspaceConfigItem,
+		workspaceRoot: string,
+		workspaceManager: WorkspaceManager,
+	): Promise<Result<{ skippedDetached: boolean; updated: boolean }, AppError>> {
 		const workspacePath = workspaceDirectory(workspaceRoot, workspace.path);
 
 		// Branch 1: Dir missing → checkout path
@@ -195,7 +338,7 @@ export class SyncService {
 				return Result.error(checkout.error);
 			}
 			console.log(green(`✅ Successfully checked out workspace: ${workspace.path}`));
-			return Result.ok({ skippedDetached: false });
+			return Result.ok({ skippedDetached: false, updated: false });
 		}
 
 		const subGit = this.deps.gitFactory(workspacePath);
@@ -220,20 +363,24 @@ export class SyncService {
 					console.log(red(`❌ Failed to check out workspace: ${workspace.path}: ${checkout.error.message}`));
 					return Result.error(checkout.error);
 				}
+				console.log(green(`✅ Successfully checked out workspace: ${workspace.path}`));
+				return Result.ok({ skippedDetached: false, updated: false });
 			}
 
 			console.log(green(`✅ Initialized submodule: ${workspace.path}`));
-			// Fall through to continue with detached check, branch check, pull
+			// Fall through to continue with detached check, branch check, sync
 		}
 
-		// Branch 3: Repo exists (or was just initialized), check if detached
-		const isDetached = await subGit.isDetachedHead();
-		if (!isDetached.ok) {
-			console.log(red(`❌ Failed to check detached state: ${workspace.path}: ${isDetached.error.message}`));
-			return Result.error(isDetached.error);
+		// Branch 3: Repo exists (or was just initialized), get branch state in one call
+		const branchStateResult = await subGit.getBranchState();
+		if (!branchStateResult.ok) {
+			console.log(red(`❌ Failed to check branch state: ${workspace.path}: ${branchStateResult.error.message}`));
+			return Result.error(branchStateResult.error);
 		}
+		const branchState = branchStateResult.value;
+		let currentBranch: string;
 
-		if (isDetached.value) {
+		if (branchState.detached) {
 			// Heal detached HEAD when HEAD is at or behind the configured branch tip.
 			// In worktree/submodule setups, git pins HEAD at the recorded gitlink SHA,
 			// which is an ancestor of the branch tip; re-attaching is a pure fast-forward.
@@ -251,7 +398,14 @@ export class SyncService {
 					console.log(red(`❌ Failed to re-attach ${workspace.path}: ${checkout.error.message}`));
 					return Result.error(checkout.error);
 				}
-				// Continue into dirty-check + pull via fall-through
+				// Re-fetch branch state after re-attachment (same as previous getCurrentBranch re-check).
+				const afterHeal = await subGit.getBranchState();
+				if (!afterHeal.ok) {
+					console.log(red(`❌ Failed to check branch state after re-attachment: ${workspace.path}: ${afterHeal.error.message}`));
+					return Result.error(afterHeal.error);
+				}
+				currentBranch = afterHeal.value.branch ?? workspace.branch;
+				// Continue into branch mismatch check + dirty-check + pull
 			} else {
 				// Detached with commits not on the configured branch
 				// WARN-AND-SKIP: never silently abandon commits
@@ -263,21 +417,15 @@ export class SyncService {
 				));
 
 				// Skip is NOT a failure; increment skippedDetachedCount
-				return Result.ok({ skippedDetached: true });
+				return Result.ok({ skippedDetached: true, updated: false });
 			}
+		} else {
+			currentBranch = branchState.branch ?? workspace.branch;
 		}
 
-		// Branch 4: On branch (or just re-attached, or just initialized) → existing flow
-
-		// Ensure correct branch (may have been re-attached or was already correct)
-		const currentBranchAfter = await subGit.getCurrentBranch();
-		if (!currentBranchAfter.ok) {
-			console.log(red(`❌ Failed to get current branch: ${workspace.path}: ${currentBranchAfter.error.message}`));
-			return Result.error(currentBranchAfter.error);
-		}
-
-		if (currentBranchAfter.value !== workspace.branch) {
-			console.log(yellow(`🔄 Switching branch for ${workspace.path} from ${currentBranchAfter.value} to ${workspace.branch}`));
+		// Branch 4: On branch (or just re-attached, or just initialized) → ensure correct branch
+		if (currentBranch !== workspace.branch) {
+			console.log(yellow(`🔄 Switching branch for ${workspace.path} from ${currentBranch} to ${workspace.branch}`));
 			const checkout = await subGit.checkoutBranch(workspace.branch);
 			if (!checkout.ok) {
 				console.log(red(`❌ Failed to switch branch for ${workspace.path}: ${checkout.error.message}`));
@@ -295,20 +443,25 @@ export class SyncService {
 			if (!dirtyResult.ok) {
 				return Result.error(dirtyResult.error);
 			}
-			return Result.ok({ skippedDetached: false });
+			return Result.ok({ skippedDetached: false, updated: dirtyResult.value.updated });
 		}
 
-		const pull = await subGit.pullOriginBranch(workspace.branch);
-		if (!pull.ok) {
-			console.log(red(`❌ Failed to pull latest changes: ${workspace.path}: ${pull.error.message}`));
-			return Result.error(pull.error);
+		const sync = await subGit.syncBranch(workspace.branch);
+		if (!sync.ok) {
+			console.log(red(`❌ Failed to sync branch: ${workspace.path}: ${sync.error.message}`));
+			return Result.error(sync.error);
 		}
-		console.log(green(`✅ Successfully pulled latest changes: ${workspace.path}`));
 
-		return Result.ok({ skippedDetached: false });
+		if (sync.value.updated) {
+			console.log(green(`✅ Updated ${workspace.path}`));
+		} else {
+			console.log(green(`✅ Already up-to-date: ${workspace.path}`));
+		}
+
+		return Result.ok({ skippedDetached: false, updated: sync.value.updated });
 	}
 
-	private async handleDirtyWorkspace(subGit: GitPort, workspace: WorkspaceConfigItem): Promise<Result<void, AppError>> {
+	private async handleDirtyWorkspace(subGit: GitPort, workspace: WorkspaceConfigItem): Promise<Result<{ updated: boolean }, AppError>> {
 		console.log(yellow(`⚠️  Workspace has uncommitted changes: ${workspace.path}`));
 
 		const stash = await subGit.stash(`workspace-manager: sync ${workspace.path}`);
@@ -318,12 +471,17 @@ export class SyncService {
 		}
 		console.log(green(`✅ Stashed changes for: ${workspace.path}`));
 
-		const pull = await subGit.pullOriginBranch(workspace.branch);
-		if (!pull.ok) {
-			console.log(red(`❌ Failed to pull latest changes: ${workspace.path}: ${pull.error.message}`));
-			return Result.error(pull.error);
+		const sync = await subGit.syncBranch(workspace.branch);
+		if (!sync.ok) {
+			console.log(red(`❌ Failed to sync branch: ${workspace.path}: ${sync.error.message}`));
+			return Result.error(sync.error);
 		}
-		console.log(green(`✅ Successfully pulled latest changes: ${workspace.path}`));
+
+		if (sync.value.updated) {
+			console.log(green(`✅ Updated ${workspace.path}`));
+		} else {
+			console.log(green(`✅ Already up-to-date: ${workspace.path}`));
+		}
 
 		const unstash = await subGit.stashPop();
 		if (!unstash.ok) {
@@ -332,7 +490,7 @@ export class SyncService {
 		}
 		console.log(green(`✅ Unstashed changes for: ${workspace.path}`));
 
-		return Result.ok();
+		return Result.ok({ updated: sync.value.updated });
 	}
 
 	private async removeInactiveWorkspace(workspace: WorkspaceConfigItem, workspaceRoot: string): Promise<Result<void, AppError>> {

--- a/src/services/sync_test.ts
+++ b/src/services/sync_test.ts
@@ -8,6 +8,7 @@ import type { GoWorkPortFactory } from "../ports/go-work.ts";
 import type { HookRunner } from "../ports/hook-runner.ts";
 import type { WorkspaceDiscoveryOptions, WorkspaceDiscoveryPort } from "../ports/workspace-discovery.ts";
 import { FakeConfigStore, FakeDiscovery, FakeFileSystem, FakeGit, FakeGoWork, FakeHookRunner } from "../testing/fakes.ts";
+import type { FakeGitState } from "../testing/fakes.ts";
 import type { WorkspaceConfig } from "../types/config.ts";
 import { SyncService } from "./sync.ts";
 
@@ -25,7 +26,7 @@ function makeDeps({
 	goAvailable,
 }: {
 	config: WorkspaceConfig;
-	gitStates?: Record<string, { currentBranch?: string; isClean?: boolean; isDetached?: boolean; isHeadBehindBranch?: boolean }>;
+	gitStates?: Record<string, FakeGitState>;
 	existingDirs?: string[];
 	goAvailable?: boolean;
 } = { config: { workspaces: [] } }) {
@@ -37,16 +38,24 @@ function makeDeps({
 	}
 
 	const gitInstances = new Map<string, FakeGit>();
+	const sharedGitStates = new Map<string, FakeGitState>();
 	const gitFactory: GitPortFactory = (cwd: string): GitPort => {
 		let git = gitInstances.get(cwd);
 		if (!git) {
 			const state = gitStates?.[cwd] ?? {};
-			git = new FakeGit({
-				currentBranch: state.currentBranch ?? "main",
-				isClean: state.isClean ?? true,
-				isDetached: state.isDetached ?? false,
-				isHeadBehindBranch: state.isHeadBehindBranch ?? false,
-			});
+			sharedGitStates.set(cwd, state);
+			git = new FakeGit(
+				{
+					currentBranch: state.currentBranch ?? "main",
+					isClean: state.isClean ?? true,
+					isDetached: state.isDetached ?? false,
+					isHeadBehindBranch: state.isHeadBehindBranch ?? false,
+					syncBranchUpdated: state.syncBranchUpdated,
+					failNext: state.failNext,
+					batchInitInitializes: state.batchInitInitializes,
+				},
+				{ cwd, sharedStates: sharedGitStates, dirs: fileSystem.dirs },
+			);
 			gitInstances.set(cwd, git);
 		}
 		return git;
@@ -86,6 +95,7 @@ function makeDeps({
 		goWorkFactory,
 		hookRunner,
 		service,
+		gitInstances,
 		getGit: (cwd: string) => gitInstances.get(cwd),
 		getGoWork: (cwd: string) => goWorkInstances.get(cwd),
 	};
@@ -109,7 +119,7 @@ Deno.test("SyncService: missing workspace dir → calls checkout (submoduleAdd)"
 	assertEquals(hookRunner.hooks.length, 0);
 });
 
-Deno.test("SyncService: existing clean repo on correct branch → pull", async () => {
+Deno.test("SyncService: existing clean repo on correct branch → syncBranch", async () => {
 	const config: WorkspaceConfig = {
 		workspaces: [
 			{ url: "git@github.com:user/repo.git", path: "repo", branch: "main", isGolang: false, active: true },
@@ -119,25 +129,33 @@ Deno.test("SyncService: existing clean repo on correct branch → pull", async (
 	const { service, getGit } = makeDeps({
 		config,
 		existingDirs: [repoPath],
-		gitStates: { [repoPath]: { currentBranch: "main", isClean: true } },
+		gitStates: { [repoPath]: { currentBranch: "main", isClean: true, syncBranchUpdated: true } },
 	});
 
 	const result = await service.run({});
 
 	assert(result.ok, `expected ok, got: ${JSON.stringify(result.error)}`);
 	assertEquals(result.value.syncedCount, 1);
+	assertEquals(result.value.updatedCount, 1);
+	assertEquals(result.value.upToDateCount, 0);
 
 	const git = getGit(repoPath);
 	if (!git) throw new Error("Expected git instance for repoPath");
-	const pullCalls = git.calls.filter((c) => c.method === "pullOriginBranch");
-	assertEquals(pullCalls.length, 1);
-	assertEquals(pullCalls[0].args[0], "main");
+	const syncCalls = git.calls.filter((c) => c.method === "syncBranch");
+	assertEquals(syncCalls.length, 1);
+	assertEquals(syncCalls[0].args[0], "main");
 
 	const subAddCalls = git.calls.filter((c) => c.method === "submoduleAdd");
 	assertEquals(subAddCalls.length, 0);
+
+	const callMethods = git.calls.map((c) => c.method);
+	assertEquals(callMethods, ["isRepository", "isRepository", "getBranchState", "isWorkingDirectoryClean", "syncBranch"]);
+	assertEquals(git.calls.filter((c) => c.method === "isDetachedHead").length, 0, "should not call isDetachedHead");
+	assertEquals(git.calls.filter((c) => c.method === "getCurrentBranch").length, 0, "should not call getCurrentBranch");
+	assertEquals(git.calls.filter((c) => c.method === "pullOriginBranch").length, 0, "should not call pullOriginBranch");
 });
 
-Deno.test("SyncService: branch mismatch → checkoutBranch then pull", async () => {
+Deno.test("SyncService: branch mismatch → checkoutBranch then syncBranch", async () => {
 	const config: WorkspaceConfig = {
 		workspaces: [
 			{ url: "git@github.com:user/repo.git", path: "repo", branch: "feature", isGolang: false, active: true },
@@ -147,20 +165,28 @@ Deno.test("SyncService: branch mismatch → checkoutBranch then pull", async () 
 	const { service, getGit } = makeDeps({
 		config,
 		existingDirs: [repoPath],
-		gitStates: { [repoPath]: { currentBranch: "main", isClean: true } },
+		gitStates: { [repoPath]: { currentBranch: "main", isClean: true, syncBranchUpdated: true } },
 	});
 
 	const result = await service.run({});
 
 	assert(result.ok, `expected ok, got: ${JSON.stringify(result.error)}`);
+	assertEquals(result.value.updatedCount, 1);
 	const git = getGit(repoPath);
 	if (!git) throw new Error("Expected git instance for repoPath");
 	const checkoutCalls = git.calls.filter((c) => c.method === "checkoutBranch");
 	assertEquals(checkoutCalls.length, 1);
 	assertEquals(checkoutCalls[0].args[0], "feature");
+
+	const branchStateCalls = git.calls.filter((c) => c.method === "getBranchState");
+	assertEquals(branchStateCalls.length, 1, "single branch-state check on non-detached repo");
+	assertEquals(git.calls.filter((c) => c.method === "getCurrentBranch").length, 0, "should not call getCurrentBranch");
+
+	const callMethods = git.calls.map((c) => c.method);
+	assertEquals(callMethods, ["isRepository", "isRepository", "getBranchState", "checkoutBranch", "isWorkingDirectoryClean", "syncBranch"]);
 });
 
-Deno.test("SyncService: detached HEAD behind branch tip → re-attach and pull", async () => {
+Deno.test("SyncService: detached HEAD behind branch tip → re-attach and syncBranch", async () => {
 	const config: WorkspaceConfig = {
 		workspaces: [
 			{ url: "git@github.com:user/repo.git", path: "repo", branch: "develop", isGolang: false, active: true },
@@ -170,23 +196,37 @@ Deno.test("SyncService: detached HEAD behind branch tip → re-attach and pull",
 	const { service, getGit } = makeDeps({
 		config,
 		existingDirs: [repoPath],
-		gitStates: { [repoPath]: { currentBranch: "HEAD", isDetached: true, isHeadBehindBranch: true } },
+		gitStates: { [repoPath]: { currentBranch: "HEAD", isDetached: true, isHeadBehindBranch: true, syncBranchUpdated: true } },
 	});
 
 	const result = await service.run({});
 
 	assert(result.ok, `expected ok, got: ${JSON.stringify(result.error)}`);
+	assertEquals(result.value.updatedCount, 1);
 	const git = getGit(repoPath);
 	if (!git) throw new Error("Expected git instance for repoPath");
 	const checkoutCalls = git.calls.filter((c) => c.method === "checkoutBranch");
-	const pullCalls = git.calls.filter((c) => c.method === "pullOriginBranch");
+	const syncCalls = git.calls.filter((c) => c.method === "syncBranch");
 	const isHeadBehindCalls = git.calls.filter((c) => c.method === "isHeadBehindBranch");
 
 	assertEquals(isHeadBehindCalls.length, 1);
 	assertEquals(checkoutCalls.length, 1);
 	assertEquals(checkoutCalls[0].args[0], "develop");
-	assertEquals(pullCalls.length, 1);
-	assertEquals(pullCalls[0].args[0], "develop");
+	assertEquals(syncCalls.length, 1);
+	assertEquals(syncCalls[0].args[0], "develop");
+
+	const callMethods = git.calls.map((c) => c.method);
+	assertEquals(callMethods, [
+		"isRepository",
+		"isRepository",
+		"getBranchState",
+		"isHeadBehindBranch",
+		"checkoutBranch",
+		"getBranchState",
+		"isWorkingDirectoryClean",
+		"syncBranch",
+	]);
+	assertEquals(git.calls.filter((c) => c.method === "isDetachedHead").length, 0, "should not call isDetachedHead");
 });
 
 Deno.test("SyncService: detached HEAD with commits not on branch → warn-and-skip", async () => {
@@ -214,9 +254,13 @@ Deno.test("SyncService: detached HEAD with commits not on branch → warn-and-sk
 	const pullCalls = git.calls.filter((c) => c.method === "pullOriginBranch");
 	assertEquals(checkoutCalls.length, 0, "should not checkout a diverged detached HEAD");
 	assertEquals(pullCalls.length, 0, "should not pull a skipped workspace");
+
+	const callMethods = git.calls.map((c) => c.method);
+	assertEquals(callMethods, ["isRepository", "isRepository", "getBranchState", "isHeadBehindBranch", "getHeadSha"]);
+	assertEquals(git.calls.filter((c) => c.method === "isDetachedHead").length, 0, "should not call isDetachedHead");
 });
 
-Deno.test("SyncService: dirty workspace → stash, pull, stashPop", async () => {
+Deno.test("SyncService: dirty workspace → stash, syncBranch, stashPop", async () => {
 	const config: WorkspaceConfig = {
 		workspaces: [
 			{ url: "git@github.com:user/repo.git", path: "repo", branch: "main", isGolang: false, active: true },
@@ -226,18 +270,30 @@ Deno.test("SyncService: dirty workspace → stash, pull, stashPop", async () => 
 	const { service, getGit } = makeDeps({
 		config,
 		existingDirs: [repoPath],
-		gitStates: { [repoPath]: { currentBranch: "main", isClean: false } },
+		gitStates: { [repoPath]: { currentBranch: "main", isClean: false, syncBranchUpdated: true } },
 	});
 
 	const result = await service.run({});
 
 	assert(result.ok, `expected ok, got: ${JSON.stringify(result.error)}`);
+	assertEquals(result.value.updatedCount, 1);
 	const git = getGit(repoPath);
 	if (!git) throw new Error("Expected git instance for repoPath");
 	const stashCalls = git.calls.filter((c) => c.method === "stash");
 	const stashPopCalls = git.calls.filter((c) => c.method === "stashPop");
 	assertEquals(stashCalls.length, 1);
 	assertEquals(stashPopCalls.length, 1);
+
+	const callMethods = git.calls.map((c) => c.method);
+	assertEquals(callMethods, [
+		"isRepository",
+		"isRepository",
+		"getBranchState",
+		"isWorkingDirectoryClean",
+		"stash",
+		"syncBranch",
+		"stashPop",
+	]);
 });
 
 Deno.test("SyncService: go.work — active golang paths in use list, inactive in remove list", async () => {
@@ -283,6 +339,59 @@ Deno.test("SyncService: global post-sync hooks → FakeHookRunner records execut
 	assertEquals(hookRunner.hooks[0].context.root, workspaceRoot);
 });
 
+Deno.test("SyncService: timing fields are populated for active workspaces", async () => {
+	const config: WorkspaceConfig = {
+		workspaces: [
+			{ url: "git@github.com:user/repo-a.git", path: "repo-a", branch: "main", isGolang: false, active: true },
+			{ url: "git@github.com:user/repo-b.git", path: "repo-b", branch: "main", isGolang: false, active: true },
+		],
+	};
+	const repoAPath = join(workspaceRoot, "repo-a");
+	const repoBPath = join(workspaceRoot, "repo-b");
+	const { service } = makeDeps({
+		config,
+		existingDirs: [repoAPath, repoBPath],
+		gitStates: {
+			[repoAPath]: { currentBranch: "main", isClean: true },
+			[repoBPath]: { currentBranch: "main", isClean: true },
+		},
+	});
+
+	const result = await service.run({});
+
+	assert(result.ok, `expected ok, got: ${JSON.stringify(result.error)}`);
+	const timing = result.value.timing;
+	assert(timing, "expected timing field on SyncReport");
+	assertEquals(typeof timing.totalMs, "number");
+	assert(timing.totalMs >= 0, "totalMs must be >= 0");
+	assert(timing.removalMs >= 0, "removalMs must be >= 0");
+	assert(timing.syncMs >= 0, "syncMs must be >= 0");
+	assert(timing.goWorkspaceMs >= 0, "goWorkspaceMs must be >= 0");
+	assert(timing.hooksMs >= 0, "hooksMs must be >= 0");
+	assertEquals(Object.keys(timing.perWorkspaceMs).length, 2);
+	assert(typeof timing.perWorkspaceMs["repo-a"] === "number");
+	assert(timing.perWorkspaceMs["repo-a"] >= 0);
+	assert(typeof timing.perWorkspaceMs["repo-b"] === "number");
+	assert(timing.perWorkspaceMs["repo-b"] >= 0);
+});
+
+Deno.test("SyncService: timing fields are sane when no active workspaces", async () => {
+	const config: WorkspaceConfig = {
+		workspaces: [
+			{ url: "git@github.com:user/repo.git", path: "repo", branch: "main", isGolang: false, active: false },
+		],
+	};
+	const { service } = makeDeps({ config });
+
+	const result = await service.run({});
+
+	assert(result.ok, `expected ok, got: ${JSON.stringify(result.error)}`);
+	const timing = result.value.timing;
+	assert(timing, "expected timing field on SyncReport");
+	assert(timing.totalMs >= 0, "totalMs must be >= 0");
+	assertEquals(Object.keys(timing.perWorkspaceMs).length, 0);
+});
+
 Deno.test("SyncService: discovery error propagates as error Result", async () => {
 	const discovery = new FakeDiscovery(Result.error(new AppError(AppErrorCode.CONFIG_NOT_FOUND, "not found")));
 	const createDiscovery = (_options: WorkspaceDiscoveryOptions): WorkspaceDiscoveryPort => discovery;
@@ -306,4 +415,241 @@ Deno.test("SyncService: discovery error propagates as error Result", async () =>
 
 	assert(!result.ok);
 	assertEquals(result.error.code, AppErrorCode.CONFIG_NOT_FOUND);
+});
+
+Deno.test("SyncService: default concurrency is 8 when not provided", async () => {
+	const config: WorkspaceConfig = {
+		workspaces: [],
+	};
+	const { service } = makeDeps({ config });
+
+	const logs: string[] = [];
+	const originalLog = console.log;
+	console.log = (...args: unknown[]) => {
+		logs.push(args.map((arg) => String(arg)).join(" "));
+	};
+
+	try {
+		const result = await service.run({ debug: true });
+		assert(result.ok, `expected ok, got: ${JSON.stringify(result.error)}`);
+	} finally {
+		console.log = originalLog;
+	}
+
+	const debugLine = logs.find((line) => line.includes("Starting workspace sync"));
+	assert(debugLine, "expected debug line to be logged");
+	assert(debugLine.includes("concurrency: 8"), `expected default concurrency 8 in debug line, got: ${debugLine}`);
+});
+
+Deno.test("SyncService: report counts updated vs up-to-date workspaces", async () => {
+	const config: WorkspaceConfig = {
+		workspaces: [
+			{ url: "git@github.com:user/repo-a.git", path: "repo-a", branch: "main", isGolang: false, active: true },
+			{ url: "git@github.com:user/repo-b.git", path: "repo-b", branch: "main", isGolang: false, active: true },
+		],
+	};
+	const repoAPath = join(workspaceRoot, "repo-a");
+	const repoBPath = join(workspaceRoot, "repo-b");
+	const { service } = makeDeps({
+		config,
+		existingDirs: [repoAPath, repoBPath],
+		gitStates: {
+			[repoAPath]: { currentBranch: "main", isClean: true, syncBranchUpdated: true },
+			[repoBPath]: { currentBranch: "main", isClean: true, syncBranchUpdated: false },
+		},
+	});
+
+	const result = await service.run({});
+
+	assert(result.ok, `expected ok, got: ${JSON.stringify(result.error)}`);
+	assertEquals(result.value.syncedCount, 2);
+	assertEquals(result.value.updatedCount, 1);
+	assertEquals(result.value.upToDateCount, 1);
+});
+
+Deno.test("SyncService: syncBranch failure propagates as error", async () => {
+	const config: WorkspaceConfig = {
+		workspaces: [
+			{ url: "git@github.com:user/repo.git", path: "repo", branch: "main", isGolang: false, active: true },
+		],
+	};
+	const repoPath = join(workspaceRoot, "repo");
+	const { service, getGit } = makeDeps({
+		config,
+		existingDirs: [repoPath],
+		gitStates: { [repoPath]: { currentBranch: "main", isClean: true, failNext: "syncBranch" } },
+	});
+
+	const result = await service.run({});
+
+	assert(!result.ok, "expected error result");
+	assertEquals(result.error.code, AppErrorCode.GIT_FAILED);
+
+	const git = getGit(repoPath);
+	if (!git) throw new Error("Expected git instance for repoPath");
+	assertEquals(git.calls.filter((c) => c.method === "syncBranch").length, 1);
+	assertEquals(git.calls.filter((c) => c.method === "pullOriginBranch").length, 0);
+});
+
+Deno.test("SyncService: dirty up-to-date workspace still stashes and pops", async () => {
+	const config: WorkspaceConfig = {
+		workspaces: [
+			{ url: "git@github.com:user/repo.git", path: "repo", branch: "main", isGolang: false, active: true },
+		],
+	};
+	const repoPath = join(workspaceRoot, "repo");
+	const { service, getGit } = makeDeps({
+		config,
+		existingDirs: [repoPath],
+		gitStates: { [repoPath]: { currentBranch: "main", isClean: false, syncBranchUpdated: false } },
+	});
+
+	const result = await service.run({});
+
+	assert(result.ok, `expected ok, got: ${JSON.stringify(result.error)}`);
+	assertEquals(result.value.syncedCount, 1);
+	assertEquals(result.value.updatedCount, 0);
+	assertEquals(result.value.upToDateCount, 1);
+
+	const git = getGit(repoPath);
+	if (!git) throw new Error("Expected git instance for repoPath");
+	const callMethods = git.calls.map((c) => c.method);
+	assertEquals(callMethods, [
+		"isRepository",
+		"isRepository",
+		"getBranchState",
+		"isWorkingDirectoryClean",
+		"stash",
+		"syncBranch",
+		"stashPop",
+	]);
+});
+
+Deno.test("SyncService: cold workspaces batched into one init call", async () => {
+	const config: WorkspaceConfig = {
+		workspaces: [
+			{ url: "git@github.com:user/repo-a.git", path: "repo-a", branch: "main", isGolang: false, active: true },
+			{ url: "git@github.com:user/repo-b.git", path: "repo-b", branch: "main", isGolang: false, active: true },
+			{ url: "git@github.com:user/repo-c.git", path: "repo-c", branch: "main", isGolang: false, active: true },
+		],
+	};
+	const { service, getGit } = makeDeps({
+		config,
+		gitStates: {
+			[workspaceRoot]: { batchInitInitializes: ["repo-a", "repo-b", "repo-c"] },
+		},
+	});
+
+	const result = await service.run({});
+
+	assert(result.ok, `expected ok, got: ${JSON.stringify(result.error)}`);
+	assertEquals(result.value.syncedCount, 3);
+	assertEquals(result.value.updatedCount, 3);
+
+	const rootGit = getGit(workspaceRoot);
+	if (!rootGit) throw new Error("Expected root git instance");
+	const batchCalls = rootGit.calls.filter((c) => c.method === "submoduleInitMany");
+	assertEquals(batchCalls.length, 1, "expected exactly one batch init call");
+	assertEquals(batchCalls[0].args, ["repo-a", "repo-b", "repo-c", "8"]);
+
+	const addCalls = rootGit.calls.filter((c) => c.method === "submoduleAdd");
+	assertEquals(addCalls.length, 0, "expected no submoduleAdd fallback calls");
+
+	for (const path of ["repo-a", "repo-b", "repo-c"]) {
+		const git = getGit(join(workspaceRoot, path));
+		if (!git) throw new Error(`Expected git instance for ${path}`);
+		assertEquals(git.calls.filter((c) => c.method === "syncBranch").length, 1);
+	}
+});
+
+Deno.test("SyncService: unregistered submodule falls back to submodule add", async () => {
+	const config: WorkspaceConfig = {
+		workspaces: [
+			{ url: "git@github.com:user/repo-a.git", path: "repo-a", branch: "main", isGolang: false, active: true },
+			{ url: "git@github.com:user/repo-b.git", path: "repo-b", branch: "main", isGolang: false, active: true },
+		],
+	};
+	const { service, getGit } = makeDeps({
+		config,
+		gitStates: {
+			[workspaceRoot]: { batchInitInitializes: ["repo-a"] },
+		},
+	});
+
+	const result = await service.run({});
+
+	assert(result.ok, `expected ok, got: ${JSON.stringify(result.error)}`);
+	assertEquals(result.value.syncedCount, 2);
+
+	const rootGit = getGit(workspaceRoot);
+	if (!rootGit) throw new Error("Expected root git instance");
+	assertEquals(rootGit.calls.filter((c) => c.method === "submoduleInitMany").length, 1);
+
+	const addCalls = rootGit.calls.filter((c) => c.method === "submoduleAdd");
+	assertEquals(addCalls.length, 1, "expected one submoduleAdd fallback call");
+	assertEquals(addCalls[0].args[1], "repo-b");
+});
+
+Deno.test("SyncService: warm run performs no batch call", async () => {
+	const config: WorkspaceConfig = {
+		workspaces: [
+			{ url: "git@github.com:user/repo.git", path: "repo", branch: "main", isGolang: false, active: true },
+		],
+	};
+	const repoPath = join(workspaceRoot, "repo");
+	const { service, gitInstances } = makeDeps({
+		config,
+		existingDirs: [repoPath],
+		gitStates: { [repoPath]: { currentBranch: "main", isClean: true, syncBranchUpdated: false } },
+	});
+
+	const result = await service.run({});
+
+	assert(result.ok, `expected ok, got: ${JSON.stringify(result.error)}`);
+	assertEquals(result.value.syncedCount, 1);
+
+	for (const git of gitInstances.values()) {
+		assertEquals(git.calls.filter((c) => c.method === "submoduleInitMany").length, 0);
+		assertEquals(git.calls.filter((c) => c.method === "submoduleAdd").length, 0);
+	}
+});
+
+Deno.test("SyncService: batch failure does not abort; per-path fallback engages", async () => {
+	const config: WorkspaceConfig = {
+		workspaces: [
+			{ url: "git@github.com:user/repo-a.git", path: "repo-a", branch: "main", isGolang: false, active: true },
+			{ url: "git@github.com:user/repo-b.git", path: "repo-b", branch: "main", isGolang: false, active: true },
+		],
+	};
+	const { service, getGit } = makeDeps({
+		config,
+		gitStates: {
+			[workspaceRoot]: { failNext: "submoduleInitMany" },
+		},
+	});
+
+	const result = await service.run({});
+
+	assert(result.ok, `expected ok, got: ${JSON.stringify(result.error)}`);
+	assertEquals(result.value.syncedCount, 2);
+
+	const rootGit = getGit(workspaceRoot);
+	if (!rootGit) throw new Error("Expected root git instance");
+	assertEquals(rootGit.calls.filter((c) => c.method === "submoduleInitMany").length, 1);
+
+	const addCalls = rootGit.calls.filter((c) => c.method === "submoduleAdd");
+	assertEquals(addCalls.length, 2, "expected fallback submoduleAdd for both pending workspaces");
+	const addPaths = addCalls.map((c) => c.args[1]);
+	assert(addPaths.includes("repo-a"));
+	assert(addPaths.includes("repo-b"));
+});
+
+Deno.test("FakeGit: submoduleInitMany with empty paths returns ok without side effects", async () => {
+	const git = new FakeGit();
+	const result = await git.submoduleInitMany([], 8);
+
+	assert(result.ok);
+	const batchCalls = git.calls.filter((c) => c.method === "submoduleInitMany");
+	assertEquals(batchCalls.length, 1);
+	assertEquals(batchCalls[0].args, ["8"]);
 });

--- a/src/services/update.ts
+++ b/src/services/update.ts
@@ -38,7 +38,7 @@ export class UpdateService {
 
 		const { workspaceRoot, configPath } = discoverResult.value;
 		const debug = input.debug ?? false;
-		const concurrency = input.concurrency ?? 4;
+		const concurrency = input.concurrency ?? 8;
 
 		const configStore = this.deps.createConfigStore(configPath);
 		const parseResult = await configStore.getConfig();

--- a/src/testing/fakes.ts
+++ b/src/testing/fakes.ts
@@ -2,7 +2,7 @@ import { Result } from "typescript-result";
 import { AppError, AppErrorCode } from "../libs/app-error.ts";
 import type { ConfigStore } from "../ports/config-store.ts";
 import type { FileSystemPort } from "../ports/file-system.ts";
-import type { GitPort } from "../ports/git.ts";
+import type { BranchState, GitPort, SyncBranchResult } from "../ports/git.ts";
 import type { GoAvailabilityPort, GoWorkPort } from "../ports/go-work.ts";
 import type { HookContext, HookExecutionResult, HookRunner } from "../ports/hook-runner.ts";
 import type { DiscoveryResult, WorkspaceDiscoveryPort } from "../ports/workspace-discovery.ts";
@@ -18,13 +18,24 @@ export type FakeGitState = {
 	isDetached?: boolean;
 	isHeadBehindBranch?: boolean;
 	headSha?: string;
+	syncBranchUpdated?: boolean;
 	failNext?: string;
+	batchInitInitializes?: string[];
+};
+
+export type FakeGitOptions = {
+	cwd?: string;
+	sharedStates?: Map<string, FakeGitState>;
+	dirs?: Set<string>;
 };
 
 export class FakeGit implements GitPort {
 	calls: { method: string; args: unknown[] }[] = [];
 
-	constructor(private readonly state: FakeGitState = {}) {}
+	constructor(
+		private readonly state: FakeGitState = {},
+		private readonly options: FakeGitOptions = {},
+	) {}
 
 	private record(method: string, args: unknown[]): void {
 		this.calls.push({ method, args });
@@ -32,7 +43,11 @@ export class FakeGit implements GitPort {
 
 	submoduleAdd(url: string, path: string, branch?: string): Promise<Result<void, AppError>> {
 		this.record("submoduleAdd", [url, path, branch]);
-		return Promise.resolve(this.nextResult());
+		const result = this.nextResult();
+		if (result.ok) {
+			this.markChildInitialized(path);
+		}
+		return Promise.resolve(result);
 	}
 
 	submoduleRemove(path: string): Promise<Result<void, AppError>> {
@@ -45,9 +60,36 @@ export class FakeGit implements GitPort {
 		const result = this.nextResult();
 		// After successful init, this path becomes a real repo
 		if (result.ok) {
-			this.state.isRepo = true;
+			this.markChildInitialized(path);
 		}
 		return Promise.resolve(result);
+	}
+
+	submoduleInitMany(paths: string[], jobs: number): Promise<Result<void, AppError>> {
+		this.record("submoduleInitMany", [...paths, String(jobs)]);
+		const result = this.nextResult();
+		if (result.ok) {
+			const toInitialize = this.state.batchInitInitializes ?? paths;
+			for (const path of toInitialize) {
+				this.markChildInitialized(path);
+			}
+		}
+		return Promise.resolve(result);
+	}
+
+	private markChildInitialized(path: string): void {
+		if (!this.options.cwd) {
+			return;
+		}
+		const childCwd = `${this.options.cwd}/${path}`;
+		if (this.options.dirs) {
+			this.options.dirs.add(childCwd);
+		}
+		if (this.options.sharedStates) {
+			const childState = this.options.sharedStates.get(childCwd) ?? {};
+			childState.isRepo = true;
+			this.options.sharedStates.set(childCwd, childState);
+		}
 	}
 
 	checkoutBranch(branch: string): Promise<Result<void, AppError>> {
@@ -74,6 +116,14 @@ export class FakeGit implements GitPort {
 		return Promise.resolve(Result.ok(this.state.isDetached ?? false));
 	}
 
+	getBranchState(): Promise<Result<BranchState, AppError>> {
+		this.record("getBranchState", []);
+		const detached = this.state.isDetached ?? false;
+		return Promise.resolve(
+			Result.ok(detached ? { detached: true, branch: null } : { detached: false, branch: this.state.currentBranch ?? "main" }),
+		);
+	}
+
 	isHeadBehindBranch(branch: string): Promise<Result<boolean, AppError>> {
 		this.record("isHeadBehindBranch", [branch]);
 		return Promise.resolve(Result.ok(this.state.isHeadBehindBranch ?? false));
@@ -89,9 +139,19 @@ export class FakeGit implements GitPort {
 		return Promise.resolve(this.nextResult());
 	}
 
+	syncBranch(branch: string): Promise<Result<SyncBranchResult, AppError>> {
+		this.record("syncBranch", [branch]);
+		if (this.state.failNext === "syncBranch") {
+			this.state.failNext = undefined;
+			return Promise.resolve(Result.error(new AppError(AppErrorCode.GIT_FAILED, "fake syncBranch failure")));
+		}
+		return Promise.resolve(Result.ok({ updated: this.state.syncBranchUpdated ?? true }));
+	}
+
 	isRepository(): Promise<Result<boolean, AppError>> {
 		this.record("isRepository", []);
-		return Promise.resolve(Result.ok(this.state.isRepo ?? true));
+		const hasDir = this.options.cwd && this.options.dirs ? this.options.dirs.has(this.options.cwd) : undefined;
+		return Promise.resolve(Result.ok(this.state.isRepo ?? hasDir ?? true));
 	}
 
 	isWorkingDirectoryClean(): Promise<Result<boolean, AppError>> {


### PR DESCRIPTION
## Summary

The `sync` command did not scale to large workspaces: every workspace paid ~6 sequential git subprocess spawns plus an unconditional `git pull`, concurrency was batch-based (one slow repo stalled an entire batch of 4), every SSH fetch paid a full TCP + auth handshake, and a cold ("first") sync cloned all submodules strictly one-by-one behind a superproject mutex.

This PR is a six-phase optimization of the sync pipeline, measured against a real production workspace (**35 active + 6 inactive submodules**, gitlab.com over high-latency SSH).

## Changes

**1. Debug timing instrumentation**
- `SyncReport.timing` collects per-workspace and per-phase durations; rendered under `--debug` only. Default output is unchanged.

**2. Worker-pool concurrency**
- `processConcurrently*` rewritten from fixed batches to a worker pool (shared index cursor), eliminating the convoy effect where one slow repo idled the remaining slots.
- Default `-j/--concurrency` raised 4 → 8.

**3. SSH connection reuse**
- Git subprocesses inject `GIT_SSH_COMMAND` with `ControlMaster=auto` / `ControlPersist=60`, removing the per-fetch handshake for SSH remotes (~3.8s → ~1.5s per fetch measured).
- Socket dir lives at `/tmp/wm-ssh-<user>` (short path required by the macOS 104-byte Unix socket limit), created with `0700` and ownership-verified; mux degrades gracefully to plain SSH on any failure.
- A user-provided `GIT_SSH_COMMAND` is always preserved verbatim (opt-out). HTTPS remotes unaffected.

**4. Fewer git spawns per workspace: 6 → 4**
- New `GitPort.getBranchState()` returns `{ detached, branch }` from a single `git symbolic-ref --short HEAD` (previously two spawns).
- `isRepository()` simplified to one `git rev-parse --show-toplevel` + realpath comparison (previously two spawns).

**5. Fetch + conditional fast-forward merge (replaces `git pull`)**
- New `GitPort.syncBranch()`: fetch → compare `HEAD` vs `origin/<branch>` → `merge --ff-only` only when behind. Up-to-date repos perform no merge and no index write.
- `SyncReport` now distinguishes **Updated** vs **Up-to-date** workspaces.
- ⚠️ **Intentional behavior change**: diverged branches now fail with remediation guidance instead of silently creating merge commits (consistent with the existing "never silently abandon commits" detached-HEAD policy).

**6. Parallel first sync**
- New `GitPort.submoduleInitMany()`: one batched `git submodule update --init --jobs=N -- <paths...>` replaces N mutex-serialized `submodule add` / `submodule update --init` calls. Cold path is now classify (parallel) → batch init (git-parallel) → per-path `submodule add` fallback only for submodules not registered in `.gitmodules`.

**Hardening & diagnostics (found during acceptance testing)**
- Git stderr is now captured into error messages (previously discarded) — root-caused the macOS socket-length failure in seconds.
- `local-install` gains `--no-prompt`: unexpected runtime permission requests fail fast with the exact missing flag instead of hanging on an unpromptable stdin.

## Measured results (real workspace, 35 submodules, high-latency SSH)

| Scenario | Before | After |
|---|---|---|
| Warm sync phase | ~35–45s (est.) | **18s** (`-j 8`) / **10.5s** (`-j 16`) |
| Cold sync (35 clones) | ~3+ min (strictly serial) | **~30s** (batched `--jobs=8`) |
| Git spawns per workspace | 6 | **4** |

## Test plan

- [x] `deno task check` — fmt + lint + **147 tests** pass
- [x] `deno test -A src/integration/` — **20 real-git integration tests** pass (batch init, ff-only merge, divergence, detached heal, worktree branches)
- [x] New unit tests: worker pool (limit/order/convoy/error-stop), git-env mux (override/fallback/length guard), `syncBranch`, `getBranchState`, batch-init orchestration
- [x] Verified against production workspace: warm sync 35/35 up-to-date; cold path (`submodule deinit` → sync) clones via batch, re-attaches branch via existing heal flow