### PR TITLE
feat(hooks): inherit terminal stdio and run workspace hooks sequentially

### DIFF
--- a/HOOKS.md
+++ b/HOOKS.md
@@ -56,7 +56,25 @@ workspaces:
 
 1. All workspaces sync (concurrent)
 2. Global hooks run once sequentially
-3. Workspace hooks run per workspace (in order)
+3. Workspace hooks run per workspace, **one workspace at a time (sequentially)** —
+   hook children share your terminal, so concurrent execution would interleave
+   output and fight over stdin
+
+## Interactivity & Output
+
+Hooks inherit the terminal: stdin, stdout, and stderr are connected directly to the
+hook process, exactly as if you ran the command yourself. This means:
+
+- **Interactive commands work as hooks** — prompts, spinners, and colored output
+  behave normally. For example, `cmd: ["workspace-manager", "link"]` as a global
+  post-sync hook can prompt for an overwrite decision and receive your answer
+- **Hook output streams live** to your terminal during execution; it is no longer
+  captured or buffered
+- **`--debug`** shows the hook's `workDir` and duration, but no `stdout:`/`stderr:`
+  dump — there is nothing captured
+
+In non-TTY environments (CI, cron), prompting hooks will fail on stdin EOF — avoid
+prompting hooks there, or have the hook detect a TTY itself.
 
 ## Execution Rules
 

--- a/src/adapters/hooks.ts
+++ b/src/adapters/hooks.ts
@@ -24,8 +24,11 @@ export class HookExecutor implements HookRunner {
 			args: substitutedCmd.slice(1),
 			cwd: substitutedWorkDir,
 			env,
-			stdout: "piped",
-			stderr: "piped",
+			// Hooks inherit the terminal: interactive commands (prompts) can read stdin
+			// and output streams live with colors, exactly as if run by the user.
+			stdin: "inherit",
+			stdout: "inherit",
+			stderr: "inherit",
 		});
 
 		const timeout = hook.timeout || 60000;
@@ -33,61 +36,51 @@ export class HookExecutor implements HookRunner {
 		// Spawn the process
 		const child = command.spawn();
 
-		// Create a timeout promise that kills the process
+		// Create a timeout promise that kills the process. With inherited stdio there is
+		// no child.output() fallback, so we race against child.status directly.
+		let timer: ReturnType<typeof setTimeout> | undefined;
 		const timeoutPromise = new Promise<never>((_, reject) => {
-			const timer = setTimeout(() => {
+			timer = setTimeout(() => {
 				child.kill();
 				reject(new Error(`Hook execution timed out after ${timeout}ms`));
 			}, timeout);
-			// Prevent unhandled rejection when timeout is cleared
-			void Promise.resolve().then(() => clearTimeout(timer));
 		});
 
 		// Wait for process to complete OR timeout using functional error handling
-		const raceResult = await Result.fromAsyncCatching(() => Promise.race([child.output(), timeoutPromise]));
+		const raceResult = await Result.fromAsyncCatching(() => Promise.race([child.status, timeoutPromise]));
+
+		// Timer is no longer needed once the race has settled (no-op if it already fired).
+		if (timer !== undefined) {
+			clearTimeout(timer);
+		}
 
 		// Handle timeout case separately from other errors
 		if (raceResult.error && raceResult.error.message.includes("timed out")) {
 			return Result.error(new AppError(AppErrorCode.HOOK_FAILED, raceResult.error.message, { cause: raceResult.error }));
 		}
 
-		// Get the output - either from race (if successful) or from child.output() fallback
-		const outputResult = raceResult.ok ? Result.ok(raceResult.value) : await Result.fromAsyncCatching(() => child.output());
-
-		if (!outputResult.ok) {
+		if (!raceResult.ok) {
 			return Result.error(
-				new AppError(AppErrorCode.HOOK_FAILED, `Hook execution failed: ${raceResult.error}`, { cause: outputResult.error }),
+				new AppError(AppErrorCode.HOOK_FAILED, `Hook execution failed: ${raceResult.error}`, { cause: raceResult.error }),
 			);
 		}
 
 		const duration = Date.now() - startTime;
-		const output = outputResult.value;
-		const stdout = new TextDecoder().decode(output.stdout);
-		const stderr = new TextDecoder().decode(output.stderr);
+		const status = raceResult.value;
 
 		if (this._debug) {
 			console.log(gray(`Hook completed in ${duration}ms`));
-			if (stdout) {
-				console.log(gray(`  stdout: ${stdout}`));
-			}
-			if (stderr) {
-				console.log(gray(`  stderr: ${stderr}`));
-			}
 		}
 
 		const executionResult: HookExecutionResult = {
-			success: output.success,
-			exitCode: output.code,
-			stdout,
-			stderr,
+			success: status.success,
+			exitCode: status.code,
 			duration,
 		};
 
-		if (!output.success) {
-			console.log(yellow(`Hook exited with non-zero status: ${output.code}`));
-			if (stderr) {
-				console.log(yellow(`  stderr: ${stderr}`));
-			}
+		if (!status.success) {
+			// stderr was already streamed live to the terminal; no re-print here.
+			console.log(yellow(`Hook exited with non-zero status: ${status.code}`));
 		}
 
 		return Result.ok(executionResult);

--- a/src/adapters/hooks_test.ts
+++ b/src/adapters/hooks_test.ts
@@ -1,4 +1,5 @@
 import { assert, assertEquals } from "@std/assert";
+import { AppErrorCode } from "../libs/app-error.ts";
 import { HookExecutor } from "./hooks.ts";
 import type { PostSyncHook } from "../types/config.ts";
 import type { HookContext } from "../ports/hook-runner.ts";
@@ -62,7 +63,7 @@ Deno.test("HookExecutor: executeHooks runs all hooks and returns results", async
 	assertEquals(result.value[1].success, true);
 });
 
-Deno.test("HookExecutor: debug=true prints workDir and duration/stdout", async () => {
+Deno.test("HookExecutor: debug=true prints workDir and duration (no captured output dump)", async () => {
 	const executor = new HookExecutor(true);
 	const capture = new ConsoleCapture();
 	const restore = capture.attach();
@@ -76,13 +77,14 @@ Deno.test("HookExecutor: debug=true prints workDir and duration/stdout", async (
 		const allOutput = capture.logs.join("\n");
 		assertEquals(allOutput.includes("workDir:"), true, "debug output should include workDir");
 		assertEquals(allOutput.includes("Hook completed in"), true, "debug output should include duration");
-		assertEquals(allOutput.includes("stdout:"), true, "debug output should include stdout");
+		assertEquals(allOutput.includes("stdout:"), false, "debug output must not dump captured stdout");
+		assertEquals(allOutput.includes("stderr:"), false, "debug output must not dump captured stderr");
 	} finally {
 		restore();
 	}
 });
 
-Deno.test("HookExecutor: debug=false omits workDir and duration/stdout", async () => {
+Deno.test("HookExecutor: debug=false omits workDir and duration", async () => {
 	const executor = new HookExecutor(false);
 	const capture = new ConsoleCapture();
 	const restore = capture.attach();
@@ -99,4 +101,56 @@ Deno.test("HookExecutor: debug=false omits workDir and duration/stdout", async (
 	} finally {
 		restore();
 	}
+});
+
+Deno.test("HookExecutor: hook output is not captured by the executor (inherited stdio)", async () => {
+	const executor = new HookExecutor(false);
+	const capture = new ConsoleCapture();
+	const restore = capture.attach();
+
+	try {
+		// The marker is built at runtime inside the child so it never appears in the echoed command line.
+		const hook: PostSyncHook = { cmd: ["deno", "eval", "console.log('hook' + '_out'); console.error('hook' + '_err')"] };
+		const result = await executor.executeHook(hook, makeCtx());
+
+		assert(result.ok, `expected ok, got: ${JSON.stringify(result.error)}`);
+		// Output streams live to the terminal; nothing is captured into console.log
+		const allOutput = capture.logs.join("\n");
+		assertEquals(allOutput.includes("hook_out"), false, "hook stdout must not be captured into executor logs");
+		assertEquals(allOutput.includes("hook_err"), false, "hook stderr must not be captured into executor logs");
+	} finally {
+		restore();
+	}
+});
+
+Deno.test("HookExecutor: hook reading stdin completes without hanging (stdin inherited)", async () => {
+	const executor = new HookExecutor(false);
+
+	// Reads stdin with a guard so the child never hangs in a non-interactive test run.
+	const script = "const readP = Deno.stdin.read(new Uint8Array(8));" +
+		"const guardP = new Promise((r) => setTimeout(() => r('guard'), 1500));" +
+		"const out = await Promise.race([readP, guardP]);" +
+		"console.log('stdin-result', out === 'guard' ? 'blocked' : out === null ? 'eof' : 'data');" +
+		"Deno.exit(0)";
+	const hook: PostSyncHook = { cmd: ["deno", "eval", script], timeout: 10000 };
+
+	const result = await executor.executeHook(hook, makeCtx());
+
+	assert(result.ok, `expected ok, got: ${JSON.stringify(result.error)}`);
+	assertEquals(result.value.success, true);
+});
+
+Deno.test("HookExecutor: timeout kills the child and returns HOOK_FAILED", async () => {
+	const executor = new HookExecutor(false);
+
+	const hook: PostSyncHook = {
+		cmd: ["deno", "eval", "await new Promise((r) => setTimeout(r, 3000))"],
+		timeout: 200,
+	};
+
+	const result = await executor.executeHook(hook, makeCtx());
+
+	assert(!result.ok, "expected error result on timeout");
+	assertEquals(result.error.code, AppErrorCode.HOOK_FAILED);
+	assert(result.error.message.includes("timed out"), `expected timeout message, got: ${result.error.message}`);
 });

--- a/src/cmds/open.ts
+++ b/src/cmds/open.ts
@@ -160,9 +160,6 @@ function processHookResult(hookResult: HookExecutionResult, workspacePath: strin
 	}
 
 	console.log(yellow(`⚠️  Hook failed for ${workspacePath} with exit code ${hookResult.exitCode}`));
-	if (hookResult.stderr) {
-		console.log(yellow(`stderr: ${hookResult.stderr}`));
-	}
 }
 
 function processGlobalHookResult(hookResult: HookExecutionResult): void {
@@ -172,7 +169,4 @@ function processGlobalHookResult(hookResult: HookExecutionResult): void {
 	}
 
 	console.log(yellow(`⚠️  Global hook failed with exit code ${hookResult.exitCode}`));
-	if (hookResult.stderr) {
-		console.log(yellow(`stderr: ${hookResult.stderr}`));
-	}
 }

--- a/src/cmds/sync.ts
+++ b/src/cmds/sync.ts
@@ -75,9 +75,6 @@ function processHookResult(hookResult: HookExecutionResult, workspacePath: strin
 	}
 
 	console.log(yellow(`⚠️  Hook failed for ${workspacePath} with exit code ${hookResult.exitCode}`));
-	if (hookResult.stderr) {
-		console.log(yellow(`stderr: ${hookResult.stderr}`));
-	}
 }
 
 function processGlobalHookResult(hookResult: HookExecutionResult): void {
@@ -87,7 +84,4 @@ function processGlobalHookResult(hookResult: HookExecutionResult): void {
 	}
 
 	console.log(yellow(`⚠️  Global hook failed with exit code ${hookResult.exitCode}`));
-	if (hookResult.stderr) {
-		console.log(yellow(`stderr: ${hookResult.stderr}`));
-	}
 }

--- a/src/ports/hook-runner.ts
+++ b/src/ports/hook-runner.ts
@@ -5,8 +5,6 @@ import type { PostSyncHook } from "../types/config.ts";
 export type HookExecutionResult = {
 	success: boolean;
 	exitCode?: number;
-	stdout: string;
-	stderr: string;
 	duration: number;
 };
 

--- a/src/services/sync.ts
+++ b/src/services/sync.ts
@@ -231,25 +231,19 @@ export class SyncService {
 		if (workspacesWithHooks.length > 0) {
 			console.log(blue(`Executing workspace-specific post-sync hooks for ${workspacesWithHooks.length} workspaces...`));
 
-			const workspaceHooksResult = await processConcurrently(
-				workspacesWithHooks,
-				async (workspace) => {
-					console.log(blue(`Executing ${workspace.postSyncHooks!.length} hooks for ${workspace.path}...`));
+			// Workspace hooks run one workspace at a time (in config order): hook children
+			// inherit the terminal, so concurrent children would interleave output and
+			// fight over stdin.
+			for (const workspace of workspacesWithHooks) {
+				console.log(blue(`Executing ${workspace.postSyncHooks!.length} hooks for ${workspace.path}...`));
 
-					const result = await hookExecutor.executeHooks(workspace.postSyncHooks!, { root: workspaceRoot, path: workspace.path });
+				const result = await hookExecutor.executeHooks(workspace.postSyncHooks!, { root: workspaceRoot, path: workspace.path });
 
-					if (!result.ok) {
-						return Result.error(result.error);
-					}
+				if (!result.ok) {
+					return Result.error(result.error);
+				}
 
-					report.workspaceHookResults.push({ path: workspace.path, results: result.value });
-					return Result.ok();
-				},
-				concurrency,
-			);
-
-			if (!workspaceHooksResult.ok) {
-				return Result.error(workspaceHooksResult.error);
+				report.workspaceHookResults.push({ path: workspace.path, results: result.value });
 			}
 		}
 

--- a/src/services/sync_test.ts
+++ b/src/services/sync_test.ts
@@ -5,11 +5,11 @@ import { AppError, AppErrorCode } from "../libs/app-error.ts";
 import type { ConfigStore } from "../ports/config-store.ts";
 import type { GitPort, GitPortFactory } from "../ports/git.ts";
 import type { GoWorkPortFactory } from "../ports/go-work.ts";
-import type { HookRunner } from "../ports/hook-runner.ts";
+import type { HookContext, HookExecutionResult, HookRunner } from "../ports/hook-runner.ts";
 import type { WorkspaceDiscoveryOptions, WorkspaceDiscoveryPort } from "../ports/workspace-discovery.ts";
 import { FakeConfigStore, FakeDiscovery, FakeFileSystem, FakeGit, FakeGoWork, FakeHookRunner } from "../testing/fakes.ts";
 import type { FakeGitState } from "../testing/fakes.ts";
-import type { WorkspaceConfig } from "../types/config.ts";
+import type { PostSyncHook, WorkspaceConfig } from "../types/config.ts";
 import { SyncService } from "./sync.ts";
 
 const workspaceRoot = "/ws";
@@ -24,11 +24,13 @@ function makeDeps({
 	gitStates,
 	existingDirs,
 	goAvailable,
+	hookRunner: customHookRunner,
 }: {
 	config: WorkspaceConfig;
 	gitStates?: Record<string, FakeGitState>;
 	existingDirs?: string[];
 	goAvailable?: boolean;
+	hookRunner?: HookRunner;
 } = { config: { workspaces: [] } }) {
 	const discovery = makeDiscovery();
 	const configStore = new FakeConfigStore(configPath, config);
@@ -72,7 +74,7 @@ function makeDeps({
 		return goWork;
 	};
 
-	const hookRunner = new FakeHookRunner();
+	const hookRunner = customHookRunner ?? new FakeHookRunner();
 
 	const createDiscovery = (_options: WorkspaceDiscoveryOptions): WorkspaceDiscoveryPort => discovery;
 	const createConfigStore = (_configPath: string): ConfigStore => configStore;
@@ -116,7 +118,7 @@ Deno.test("SyncService: missing workspace dir → calls checkout (submoduleAdd)"
 	assertEquals(result.value.syncedCount, 1);
 	assertEquals(result.value.removedCount, 0);
 	// No global hooks configured → no hook calls
-	assertEquals(hookRunner.hooks.length, 0);
+	assertEquals((hookRunner as FakeHookRunner).hooks.length, 0);
 });
 
 Deno.test("SyncService: existing clean repo on correct branch → syncBranch", async () => {
@@ -334,9 +336,9 @@ Deno.test("SyncService: global post-sync hooks → FakeHookRunner records execut
 
 	assert(result.ok, `expected ok, got: ${JSON.stringify(result.error)}`);
 	// 2 global hooks should have been recorded
-	assertEquals(hookRunner.hooks.length, 2);
-	assertEquals(hookRunner.hooks[0].hook.cmd[0], "echo");
-	assertEquals(hookRunner.hooks[0].context.root, workspaceRoot);
+	assertEquals((hookRunner as FakeHookRunner).hooks.length, 2);
+	assertEquals((hookRunner as FakeHookRunner).hooks[0].hook.cmd[0], "echo");
+	assertEquals((hookRunner as FakeHookRunner).hooks[0].context.root, workspaceRoot);
 });
 
 Deno.test("SyncService: timing fields are populated for active workspaces", async () => {
@@ -642,6 +644,70 @@ Deno.test("SyncService: batch failure does not abort; per-path fallback engages"
 	const addPaths = addCalls.map((c) => c.args[1]);
 	assert(addPaths.includes("repo-a"));
 	assert(addPaths.includes("repo-b"));
+});
+
+/**
+ * Records per-executeHooks-call start/end events so tests can assert that
+ * workspace hooks run one workspace at a time (no interleaving).
+ */
+class TrackingHookRunner implements HookRunner {
+	events: Array<{ workspace: string; phase: "start" | "end" }> = [];
+
+	constructor(private readonly delayMs: number = 20) {}
+
+	executeHook(_hook: PostSyncHook, _context: HookContext): Promise<Result<HookExecutionResult, AppError>> {
+		return Promise.resolve(Result.ok({ success: true, exitCode: 0, duration: 0 }));
+	}
+
+	async executeHooks(hooks: PostSyncHook[], context: HookContext): Promise<Result<HookExecutionResult[], AppError>> {
+		this.events.push({ workspace: context.path, phase: "start" });
+		await new Promise((resolve) => setTimeout(resolve, this.delayMs));
+		this.events.push({ workspace: context.path, phase: "end" });
+		return Promise.resolve(Result.ok(hooks.map(() => ({ success: true, exitCode: 0, duration: 0 }))));
+	}
+}
+
+Deno.test("SyncService: workspace post-sync hooks execute sequentially in config order", async () => {
+	const config: WorkspaceConfig = {
+		workspaces: [
+			{
+				url: "git@github.com:user/repo-a.git",
+				path: "repo-a",
+				branch: "main",
+				isGolang: false,
+				active: true,
+				postSyncHooks: [{ cmd: ["echo", "a1"] }, { cmd: ["echo", "a2"] }],
+			},
+			{
+				url: "git@github.com:user/repo-b.git",
+				path: "repo-b",
+				branch: "main",
+				isGolang: false,
+				active: true,
+				postSyncHooks: [{ cmd: ["echo", "b1"] }],
+			},
+		],
+	};
+	const repoAPath = join(workspaceRoot, "repo-a");
+	const repoBPath = join(workspaceRoot, "repo-b");
+	const trackingRunner = new TrackingHookRunner(20);
+	const { service } = makeDeps({
+		config,
+		existingDirs: [repoAPath, repoBPath],
+		gitStates: {
+			[repoAPath]: { currentBranch: "main", isClean: true, syncBranchUpdated: false },
+			[repoBPath]: { currentBranch: "main", isClean: true, syncBranchUpdated: false },
+		},
+		hookRunner: trackingRunner,
+	});
+
+	const result = await service.run({});
+
+	assert(result.ok, `expected ok, got: ${JSON.stringify(result.error)}`);
+	assertEquals(result.value.workspaceHookResults.length, 2);
+	// Hooks for workspace N+1 must not start until workspace N's hooks have completed.
+	const phases = trackingRunner.events.map((e) => `${e.workspace}:${e.phase}`);
+	assertEquals(phases, ["repo-a:start", "repo-a:end", "repo-b:start", "repo-b:end"]);
 });
 
 Deno.test("FakeGit: submoduleInitMany with empty paths returns ok without side effects", async () => {

--- a/src/testing/fakes.ts
+++ b/src/testing/fakes.ts
@@ -354,8 +354,6 @@ export class FakeHookRunner implements HookRunner {
 			Result.ok({
 				success: true,
 				exitCode: 0,
-				stdout: "",
-				stderr: "",
 				duration: 0,
 			}),
 		);
@@ -368,8 +366,6 @@ export class FakeHookRunner implements HookRunner {
 			results.push({
 				success: true,
 				exitCode: 0,
-				stdout: "",
-				stderr: "",
 				duration: 0,
 			});
 		}


### PR DESCRIPTION
## Summary

Changes post-sync hook execution so that hook children **inherit the terminal** (stdin, stdout, and stderr) instead of having their output captured via pipes. Hook output now streams live to the terminal, and interactive commands — prompts, spinners, colored output — behave exactly as if the user ran them directly.

Because inherited stdio makes concurrent hook children fight over the same terminal, workspace hooks now run **sequentially** (one workspace at a time, in config order) rather than concurrently.

## Changes

- **`src/adapters/hooks.ts`** — Hook children are spawned with `stdin/stdout/stderr: "inherit"`. The executor races `child.status` instead of `child.output()` (no captured output to buffer). Timer cleanup and error handling simplified accordingly.
- **`src/services/sync.ts`** — Workspace-specific post-sync hooks now run sequentially via a `for...of` loop instead of `processConcurrently`. Global hooks remain concurrent as before.
- **`HOOKS.md`** — Documents the new execution order, interactivity guarantees, and the non-TTY caveat (prompting hooks will fail on stdin EOF in CI/cron).
- **Tests** — Updated fake hook runner and sync tests to reflect the new sequential workspace-hook execution and the absence of captured stdout/stderr.

## Why

Captured stdio prevented hooks from being interactive. A post-sync hook such as `workspace-manager link` could not prompt for an overwrite decision, and spinner/color output was lost in buffering. Inheriting the terminal makes hooks first-class interactive steps.

## Caveat

In non-TTY environments (CI, cron), hooks that prompt will fail on stdin EOF. Users should avoid prompting hooks there, or have the hook detect a TTY itself.

## Checklist

- [x] `deno fmt` and `deno lint` clean
- [x] `deno task test` passes
- [x] HOOKS.md updated