### PR TITLE
feat: add WM_CONCURRENCY environment variable for global default concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,21 @@ Host github.com
   ControlPersist 60
 ```
 
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `WM_CONCURRENCY` | Default concurrency for all commands that support `-j` flag. Overrides the built-in default of 8. CLI flag `-j` takes precedence when provided. |
+| `EDITOR` / `VISUAL` | Default editor for the `open` command. Overridden by `--editor` flag or `editor` config. |
+| `GIT_SSH_COMMAND` | Custom SSH command for Git operations. When set, SSH connection multiplexing is disabled. |
+
+**Example:**
+```bash
+export WM_CONCURRENCY=4
+workspace-manager sync  # uses concurrency 4
+workspace-manager sync -j 16  # uses concurrency 16 (flag overrides env var)
+```
+
 ## Installation
 
 Requires Deno 2.4 or later.
@@ -104,7 +119,7 @@ workspace-manager sync [options]
 - `-c, --config <file>` - Workspace config file (default: workspace.yml)
 - `-w, --workspace-root <path>` - Workspace root directory (default: .)
 - `-d, --debug` - Enable debug mode
-- `-j, --concurrency <number>` - Number of concurrent operations (default: 4)
+- `-j, --concurrency <number>` - Number of concurrent operations (default: $WM_CONCURRENCY or 8)
 - `-y, --yes` - Accept all changes (⚠️ not yet implemented)
 
 **Sync behavior:**
@@ -134,7 +149,7 @@ workspace-manager update [options]
 - `-c, --config <file>` - Workspace config file (default: workspace.yml)
 - `-w, --workspace-root <path>` - Workspace root directory (default: .)
 - `-d, --debug` - Enable debug mode
-- `-j, --concurrency <number>` - Number of concurrent operations (default: 4)
+- `-j, --concurrency <number>` - Number of concurrent operations (default: $WM_CONCURRENCY or 8)
 
 ### Enable Command
 
@@ -158,7 +173,7 @@ This command will:
 - `-c, --config <file>` - Workspace config file (default: workspace.yml)
 - `-w, --workspace-root <path>` - Workspace root directory (default: .)
 - `-d, --debug` - Enable debug mode
-- `-j, --concurrency <number>` - Number of concurrent operations (default: 4)
+- `-j, --concurrency <number>` - Number of concurrent operations (default: $WM_CONCURRENCY or 8)
 - `-y, --yes` - Automatically sync after enabling without prompting
 
 ### Save Command
@@ -363,7 +378,7 @@ This command will:
 - `-c, --config <file>` - Workspace config file (default: workspace.yml)
 - `-w, --workspace-root <path>` - Workspace root directory (default: .)
 - `-d, --debug` - Enable debug mode
-- `-j, --concurrency <number>` - Number of concurrent operations (default: 4)
+- `-j, --concurrency <number>` - Number of concurrent operations (default: $WM_CONCURRENCY or 8)
 - `-b, --branch <branch>` - Git branch to checkout (default: main)
 - `--go` - Mark as Go module for go.work integration (default: false)
 - `--sync` - Sync workspace after adding repository (default: false)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,6 +12,7 @@ import { createAppContext } from "./composition.ts";
 import { CommandErrorHandler } from "./libs/command-error-handler.ts";
 import { linkCommand } from "./cmds/link.ts";
 import { unlinkCommand } from "./cmds/unlink.ts";
+import { getDefaultConcurrency } from "./libs/env.ts";
 
 // Create CLI application
 export const cli = new Command()
@@ -27,10 +28,7 @@ cli
 	.option("-d, --debug", "Enable debug mode", { default: false })
 	.option(
 		"-j, --concurrency <concurrency:number>",
-		"Number of concurrent operations",
-		{
-			default: 8,
-		},
+		"Number of concurrent operations (default: $WM_CONCURRENCY or 8)",
 	)
 	.option("-y, --yes", "Accept all changes")
 	.action(async (options) => {
@@ -39,7 +37,7 @@ cli
 			config: options.config,
 			workspaceRoot: options.workspaceRoot,
 			debug: options.debug,
-			concurrency: options.concurrency,
+			concurrency: options.concurrency ?? getDefaultConcurrency(),
 		});
 		CommandErrorHandler.withExit(result, "Sync", { debug: options.debug });
 	});
@@ -55,10 +53,7 @@ cli
 	.option("-d, --debug", "Enable debug mode", { default: false })
 	.option(
 		"-j, --concurrency <concurrency:number>",
-		"Number of concurrent operations",
-		{
-			default: 8,
-		},
+		"Number of concurrent operations (default: $WM_CONCURRENCY or 8)",
 	)
 	.action(async (options) => {
 		const ctx = createAppContext({ debug: options.debug });
@@ -66,7 +61,7 @@ cli
 			config: options.config,
 			workspaceRoot: options.workspaceRoot,
 			debug: options.debug,
-			concurrency: options.concurrency,
+			concurrency: options.concurrency ?? getDefaultConcurrency(),
 		});
 		CommandErrorHandler.withExit(result, "Update", { debug: options.debug });
 	});
@@ -79,10 +74,7 @@ cli
 	.option("-d, --debug", "Enable debug mode", { default: false })
 	.option(
 		"-j, --concurrency <concurrency:number>",
-		"Number of concurrent operations",
-		{
-			default: 8,
-		},
+		"Number of concurrent operations (default: $WM_CONCURRENCY or 8)",
 	)
 	.option("-y, --yes", "Skip sync confirmation prompt")
 	.action(async (options) => {
@@ -91,7 +83,7 @@ cli
 			config: options.config,
 			workspaceRoot: options.workspaceRoot,
 			debug: options.debug,
-			concurrency: options.concurrency,
+			concurrency: options.concurrency ?? getDefaultConcurrency(),
 			yes: options.yes,
 		});
 		CommandErrorHandler.withExit(result, "Enable", { debug: options.debug });
@@ -127,10 +119,7 @@ cli
 	.option("-d, --debug", "Enable debug mode", { default: false })
 	.option(
 		"-j, --concurrency <concurrency:number>",
-		"Number of concurrent operations",
-		{
-			default: 8,
-		},
+		"Number of concurrent operations (default: $WM_CONCURRENCY or 8)",
 	)
 	.option("-b, --branch <branch:string>", "Git branch to checkout", {
 		default: "main",
@@ -158,7 +147,7 @@ cli
 			config: options.config,
 			workspaceRoot: options.workspaceRoot,
 			debug: options.debug,
-			concurrency: options.concurrency,
+			concurrency: options.concurrency ?? getDefaultConcurrency(),
 		});
 		CommandErrorHandler.withExit(result, "Add", { debug: options.debug });
 	});
@@ -172,10 +161,7 @@ cli
 	.option("-d, --debug", "Enable debug mode", { default: false })
 	.option(
 		"-j, --concurrency <concurrency:number>",
-		"Number of concurrent operations",
-		{
-			default: 8,
-		},
+		"Number of concurrent operations (default: $WM_CONCURRENCY or 8)",
 	)
 	.option("--json", "Output in JSON format", { default: false })
 	.option("-v, --verbose", "Show verbose git information", { default: false })
@@ -185,7 +171,7 @@ cli
 			config: options.config,
 			workspaceRoot: options.workspaceRoot,
 			debug: options.debug,
-			concurrency: options.concurrency,
+			concurrency: options.concurrency ?? getDefaultConcurrency(),
 			json: options.json,
 			verbose: options.verbose,
 		});

--- a/src/libs/env.ts
+++ b/src/libs/env.ts
@@ -1,0 +1,18 @@
+/**
+ * Get default concurrency from WM_CONCURRENCY environment variable.
+ * Falls back to 8 if not set or invalid.
+ * Minimum value is 1.
+ */
+export function getDefaultConcurrency(): number {
+	const envValue = Deno.env.get("WM_CONCURRENCY");
+	if (envValue === undefined) {
+		return 8;
+	}
+
+	const parsed = parseInt(envValue, 10);
+	if (isNaN(parsed) || parsed < 1) {
+		return 8;
+	}
+
+	return parsed;
+}

--- a/src/libs/env_test.ts
+++ b/src/libs/env_test.ts
@@ -1,0 +1,72 @@
+import { assertEquals } from "@std/assert";
+import { getDefaultConcurrency } from "./env.ts";
+
+Deno.test("getDefaultConcurrency: returns 8 when WM_CONCURRENCY is not set", () => {
+	assertEquals(getDefaultConcurrency(), 8);
+});
+
+Deno.test("getDefaultConcurrency: parses WM_CONCURRENCY correctly when valid", async (t) => {
+	// Save original
+	const original = Deno.env.get("WM_CONCURRENCY");
+
+	try {
+		await t.step("valid positive integer", () => {
+			Deno.env.set("WM_CONCURRENCY", "4");
+			assertEquals(getDefaultConcurrency(), 4);
+		});
+
+		await t.step("large value", () => {
+			Deno.env.set("WM_CONCURRENCY", "64");
+			assertEquals(getDefaultConcurrency(), 64);
+		});
+
+		await t.step("value of 1", () => {
+			Deno.env.set("WM_CONCURRENCY", "1");
+			assertEquals(getDefaultConcurrency(), 1);
+		});
+	} finally {
+		// Restore original
+		if (original !== undefined) {
+			Deno.env.set("WM_CONCURRENCY", original);
+		} else {
+			Deno.env.delete("WM_CONCURRENCY");
+		}
+	}
+});
+
+Deno.test("getDefaultConcurrency: falls back to 8 when WM_CONCURRENCY is invalid", async (t) => {
+	const original = Deno.env.get("WM_CONCURRENCY");
+
+	try {
+		await t.step("non-numeric string", () => {
+			Deno.env.set("WM_CONCURRENCY", "abc");
+			assertEquals(getDefaultConcurrency(), 8);
+		});
+
+		await t.step("empty string", () => {
+			Deno.env.set("WM_CONCURRENCY", "");
+			assertEquals(getDefaultConcurrency(), 8);
+		});
+
+		await t.step("zero", () => {
+			Deno.env.set("WM_CONCURRENCY", "0");
+			assertEquals(getDefaultConcurrency(), 8);
+		});
+
+		await t.step("negative number", () => {
+			Deno.env.set("WM_CONCURRENCY", "-2");
+			assertEquals(getDefaultConcurrency(), 8);
+		});
+
+		await t.step("float string", () => {
+			Deno.env.set("WM_CONCURRENCY", "4.5");
+			assertEquals(getDefaultConcurrency(), 4); // parseInt truncates
+		});
+	} finally {
+		if (original !== undefined) {
+			Deno.env.set("WM_CONCURRENCY", original);
+		} else {
+			Deno.env.delete("WM_CONCURRENCY");
+		}
+	}
+});

--- a/src/services/status.ts
+++ b/src/services/status.ts
@@ -8,6 +8,7 @@ import type { GitPortFactory } from "../ports/git.ts";
 import type { WorkspaceDiscoveryOptions, WorkspaceDiscoveryPort } from "../ports/workspace-discovery.ts";
 import type { WorkspaceConfigItem } from "../types/config.ts";
 import { blue } from "@std/fmt/colors";
+import { getDefaultConcurrency } from "../libs/env.ts";
 
 export type RepositoryReadiness = "ready" | "not_initialized" | "detached_at_tip" | "detached";
 
@@ -64,7 +65,7 @@ export class StatusService {
 
 		const { workspaceRoot, configPath } = discoverResult.value;
 		const debug = input.debug ?? false;
-		const concurrency = input.concurrency ?? 8;
+		const concurrency = input.concurrency ?? getDefaultConcurrency();
 		const verbose = input.verbose ?? false;
 
 		const configStore = this.deps.createConfigStore(configPath);

--- a/src/services/sync.ts
+++ b/src/services/sync.ts
@@ -10,6 +10,7 @@ import type { HookContext, HookExecutionResult, HookRunner } from "../ports/hook
 import type { WorkspaceDiscoveryOptions, WorkspaceDiscoveryPort } from "../ports/workspace-discovery.ts";
 import type { WorkspaceConfigItem } from "../types/config.ts";
 import { blue, green, red, yellow } from "@std/fmt/colors";
+import { getDefaultConcurrency } from "../libs/env.ts";
 import { WorkspaceManager } from "./workspace-manager.ts";
 
 export type SyncTiming = {
@@ -70,7 +71,7 @@ export class SyncService {
 		}
 
 		const { workspaceRoot, configPath } = discoverResult.value;
-		const concurrency = input.concurrency ?? 8;
+		const concurrency = input.concurrency ?? getDefaultConcurrency();
 		const debug = input.debug ?? false;
 		const totalStart = performance.now();
 

--- a/src/services/update.ts
+++ b/src/services/update.ts
@@ -7,6 +7,7 @@ import type { FileSystemPort } from "../ports/file-system.ts";
 import type { GitPortFactory } from "../ports/git.ts";
 import type { WorkspaceDiscoveryOptions, WorkspaceDiscoveryPort } from "../ports/workspace-discovery.ts";
 import { blue, gray, green, red, yellow } from "@std/fmt/colors";
+import { getDefaultConcurrency } from "../libs/env.ts";
 
 export type UpdateServiceDeps = {
 	createDiscovery(options: WorkspaceDiscoveryOptions): WorkspaceDiscoveryPort;
@@ -38,7 +39,7 @@ export class UpdateService {
 
 		const { workspaceRoot, configPath } = discoverResult.value;
 		const debug = input.debug ?? false;
-		const concurrency = input.concurrency ?? 8;
+		const concurrency = input.concurrency ?? getDefaultConcurrency();
 
 		const configStore = this.deps.createConfigStore(configPath);
 		const parseResult = await configStore.getConfig();


### PR DESCRIPTION
## Summary

Add `WM_CONCURRENCY` environment variable that sets the default concurrency for all commands that support the `-j`/`--concurrency` flag. This allows users to configure a global concurrency default without repeating the flag on every invocation.

## Resolution Order

1. CLI `-j`/`--concurrency` flag (highest priority)
2. `WM_CONCURRENCY` environment variable
3. Built-in default of 8 (lowest priority)

## Changes

| File | Change |
|------|--------|
| `src/libs/env.ts` | New helper `getDefaultConcurrency()` — reads `WM_CONCURRENCY`, validates input, falls back to 8 |
| `src/libs/env_test.ts` | Unit tests covering: unset, valid values, invalid/non-numeric, zero/negative, float truncation |
| `src/cli.ts` | All command actions now use `options.concurrency ?? getDefaultConcurrency()` instead of hardcoded `{ default: 8 }` |
| `src/services/sync.ts` | Uses `getDefaultConcurrency()` as programmatic fallback |
| `src/services/status.ts` | Same |
| `src/services/update.ts` | Same |
| `README.md` | Added Environment Variables section; updated all `-j` flag docs to show `$WM_CONCURRENCY or 8` |

## Usage

```bash
export WM_CONCURRENCY=4
workspace-manager sync      # uses concurrency 4
workspace-manager sync -j 16 # uses concurrency 16 (flag overrides)
```

Invalid values (non-numeric, empty, zero, negative) fall back to 8 safely.

Closes #??